### PR TITLE
[fix] #15 Outbox 메시지 처리 순서로 인한 SAGA 상태 불일치 오류 수정

### DIFF
--- a/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
@@ -18,6 +18,7 @@ import com.orderingsystem.order.domain.repository.OrderRepository;
 import com.orderingsystem.order.domain.service.PayOrderService;
 import com.orderingsystem.outbox.OutboxStatus;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,16 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
         }
         PaymentOutbox paymentOutboxMessage = paymentOutboxMessageResponse.get();
 
-        OrderPaidEvent orderPaidEvent = completedPaymentForOrder(paymentResponse);
+        Order order = findOrder(paymentResponse.getOrderId());
+
+        if (order.getOrderStatus() == OrderStatus.APPROVED
+                || order.getOrderStatus() == OrderStatus.CANCELLED
+                || order.getOrderStatus() == OrderStatus.CANCELLING) {
+            log.info("주문이 이미 승인/취소 처리된 상태입니다. 결제 처리를 생략합니다. Order Id : {}", paymentResponse.getOrderId());
+            return;
+        }
+
+        OrderPaidEvent orderPaidEvent = completedPaymentForOrder(order);
 
         SagaStatus sagaStatus =
                 OrderStatusToSagaStatus.orderStatusToSagaStatus(orderPaidEvent.getOrder().getOrderStatus());
@@ -86,7 +96,16 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
         }
         PaymentOutbox paymentOutbox = paymentOutboxMessageResponse.get();
 
-        Order order = rollbackPaymentForOrder(paymentResponse);
+        Order order = findOrder(paymentResponse.getOrderId());
+
+        if (order.getOrderStatus() == OrderStatus.APPROVED
+                || order.getOrderStatus() == OrderStatus.CANCELLED
+                || order.getOrderStatus() == OrderStatus.CANCELLING) {
+            log.info("주문이 이미 승인/취소 처리된 상태입니다. 결제 처리를 생략합니다. Order Id : {}", paymentResponse.getOrderId());
+            return;
+        }
+
+        rollbackPaymentForOrder(order, paymentResponse);
 
         SagaStatus sagaStatus = OrderStatusToSagaStatus.orderStatusToSagaStatus(order.getOrderStatus());
         updatePaymentOutboxMessage(paymentOutbox, order.getOrderStatus(), sagaStatus);
@@ -98,10 +117,8 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
         log.info("해당 주문의 주문 취소가 성공적으로 완료되었습니다. Order Id : {}", paymentResponse.getOrderId());
     }
 
-    private OrderPaidEvent completedPaymentForOrder(PaymentResponse paymentResponse) {
-        log.info("결제 처리 시작. Order Id : {}", paymentResponse.getOrderId());
-
-        Order order = findOrder(paymentResponse.getOrderId());
+    private OrderPaidEvent completedPaymentForOrder(Order order) {
+        log.info("결제 처리 시작. Order Id : {}", order.getId());
         return payOrderService.payOrder(order);
     }
 
@@ -113,10 +130,8 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
         };
     }
 
-    private Order rollbackPaymentForOrder(PaymentResponse paymentResponse) {
-        Order order = findOrder(paymentResponse.getOrderId());
+    private void rollbackPaymentForOrder(Order order, PaymentResponse paymentResponse) {
         order.cancel(paymentResponse.getFailureMessages());
-        return order;
     }
 
     private void updateApprovalOutboxMessage(UUID sagaId, OrderStatus orderStatus,

--- a/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
@@ -58,7 +58,7 @@ public class OrderRestaurantApprovalService implements SagaStep<RestaurantApprov
         if (order.getOrderStatus() == OrderStatus.APPROVED
                 || order.getOrderStatus() == OrderStatus.CANCELLED
                 || order.getOrderStatus() == OrderStatus.CANCELLING) {
-            log.info("주문이 이미 승인/취소 처리된 상태입니다. Outbox 업데이트를 생략합니다. Order Id : {}",
+            log.info("주문이 이미 {} 상태입니다. Outbox 업데이트를 생략합니다. Order Id : {}", order.getOrderStatus().name(),
                     restaurantApprovalResponse.getOrderId());
 
             return;
@@ -92,7 +92,19 @@ public class OrderRestaurantApprovalService implements SagaStep<RestaurantApprov
 
         RestaurantApprovalOutbox restaurantApprovalOutbox = restaurantApprovalOutboxResponse.get();
 
-        OrderCancelledEvent orderCancelledEvent = rollbackOrder(restaurantApprovalResponse);
+        Order order = findOrder(restaurantApprovalResponse.getOrderId());
+
+        if (order.getOrderStatus() == OrderStatus.APPROVED
+                || order.getOrderStatus() == OrderStatus.CANCELLED
+                || order.getOrderStatus() == OrderStatus.CANCELLING) {
+            log.info("주문이 이미 {} 상태입니다. Outbox 업데이트를 생략합니다. Order Id : {}", order.getOrderStatus().name(),
+                    restaurantApprovalResponse.getOrderId());
+
+            return;
+        }
+
+        OrderCancelledEvent orderCancelledEvent = orderPaymentCancelService.cancelOrderPayment(order,
+                restaurantApprovalResponse.getFailureMessages());
 
         SagaStatus sagaStatus =
                 OrderStatusToSagaStatus.orderStatusToSagaStatus(orderCancelledEvent.getOrder().getOrderStatus());
@@ -114,11 +126,6 @@ public class OrderRestaurantApprovalService implements SagaStep<RestaurantApprov
     private void approvalOrder(Order order) {
         order.approve();
         log.info("주문 승인 완료. Order Id : {}", order.getId());
-    }
-
-    private OrderCancelledEvent rollbackOrder(RestaurantApprovalResponse restaurantApprovalResponse) {
-        Order order = findOrder(restaurantApprovalResponse.getOrderId());
-        return orderPaymentCancelService.cancelOrderPayment(order, restaurantApprovalResponse.getFailureMessages());
     }
 
     private void updateApprovalOutbox(RestaurantApprovalOutbox restaurantApprovalOutbox,

--- a/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
@@ -53,7 +53,19 @@ public class OrderRestaurantApprovalService implements SagaStep<RestaurantApprov
 
         RestaurantApprovalOutbox restaurantApprovalOutbox = restaurantApprovalOutboxResponse.get();
 
-        Order order = approvalOrder(restaurantApprovalResponse);
+        Order order = findOrder(restaurantApprovalResponse.getOrderId());
+
+        if (order.getOrderStatus() == OrderStatus.APPROVED
+                || order.getOrderStatus() == OrderStatus.CANCELLED
+                || order.getOrderStatus() == OrderStatus.CANCELLING) {
+            log.info("주문이 이미 승인/취소 처리된 상태입니다. Outbox 업데이트를 생략합니다. Order Id : {}",
+                    restaurantApprovalResponse.getOrderId());
+
+            return;
+        }
+
+        approvalOrder(order);
+
         SagaStatus sagaStatus = OrderStatusToSagaStatus.orderStatusToSagaStatus(order.getOrderStatus());
 
         updateApprovalOutbox(restaurantApprovalOutbox, order.getOrderStatus(), sagaStatus);
@@ -99,11 +111,9 @@ public class OrderRestaurantApprovalService implements SagaStep<RestaurantApprov
                 String.join(",", restaurantApprovalResponse.getFailureMessages()));
     }
 
-    private Order approvalOrder(RestaurantApprovalResponse restaurantApprovalResponse) {
-        Order order = findOrder(restaurantApprovalResponse.getOrderId());
+    private void approvalOrder(Order order) {
         order.approve();
-        log.info("주문 승인 완료. Order Id : {}", restaurantApprovalResponse.getOrderId());
-        return order;
+        log.info("주문 승인 완료. Order Id : {}", order.getId());
     }
 
     private OrderCancelledEvent rollbackOrder(RestaurantApprovalResponse restaurantApprovalResponse) {

--- a/order/src/main/java/com/orderingsystem/order/application/outbox/payment/PaymentOutboxHelper.java
+++ b/order/src/main/java/com/orderingsystem/order/application/outbox/payment/PaymentOutboxHelper.java
@@ -86,4 +86,8 @@ public class PaymentOutboxHelper {
     public Optional<PaymentOutbox> getPaymentOutboxBySagaIdAndSagaStatus(UUID sagaId, SagaStatus... sagaStatus) {
         return paymentOutboxRepository.findByTypeAndSagaIdAndSagaStatusIn(ORDER_SAGA_NAME, sagaId, Arrays.asList(sagaStatus));
     }
+
+    public Optional<PaymentOutbox> getPaymentOutboxBySagaIdAndSagaStatusIn(UUID sagaId, List<SagaStatus> started) {
+        return null;
+    }
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/application/RestaurantService.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/application/RestaurantService.java
@@ -68,10 +68,10 @@ public class RestaurantService {
     }
 
     private boolean isOutboxMessageProcessedForApproval(ApprovalRequest approvalRequest) {
-        Optional<OrderOutbox> orderOutboxMessage = orderOutboxRepository.findByTypeAndSagaIdAndOutboxStatus(
+        List<OrderOutbox> orderOutboxMessage = orderOutboxRepository.findByTypeAndSagaIdAndOutboxStatus(
                 ORDER_SAGA_NAME, approvalRequest.getSagaId(), OutboxStatus.COMPLETED);
 
-        return orderOutboxMessage.isPresent();
+        return !orderOutboxMessage.isEmpty();
     }
 
     private Restaurant findRestaurant(UUID restaurantId) {

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/outbox/OrderOutboxRepository.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/outbox/OrderOutboxRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> {
 
-    Optional<OrderOutbox> findByTypeAndSagaIdAndOutboxStatus(String type, UUID sagaId, OutboxStatus outboxStatus);
+    List<OrderOutbox> findByTypeAndSagaIdAndOutboxStatus(String type, UUID sagaId, OutboxStatus outboxStatus);
 
     Optional<List<OrderOutbox>> findByTypeAndOutboxStatus(String orderSagaName, OutboxStatus outboxStatus);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

### 문제
- 결제 → 레스토랑 승인 순서로 진행되는 흐름에서, PaymentOutbox 메시지가 RestaurantApprovalOutbox 메시지보다 늦게 처리되는 경우가 발생
-  Order의 상태가 이미 APPROVED인데도, 늦게 도착한 PaymentResponse 메시지가 다시 결제를 시도하게 되어 중복 처리되거나 PaymentOutbox의 상태를 PROCESSING으로 변경하지 못해 OrderRestaurantApprovalService에서 예외가 발생

---

### 해결 방법
- Order 상태가 이미 APPROVED, CANCELLED, CANCELLING인 경우, 처리 로직과 Outbox 업데이트를 생략
- RestaurantApprovalService에서 PaymentOutbox 조회 시 SagaStatus.PROCESSING이 없으면 예외 대신 생략 처리
