### PR TITLE
[Fix] #17 outbox 중복 저장 방지 및 낙관적 락 기반 재처리 개선

### DIFF
--- a/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.orderingsystem.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -22,4 +25,13 @@ public class GlobalExceptionHandler {
                 .build();
     }
 
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ErrorDTO handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.error("유니크 키 중복 오류 발생", e);
+
+        return ErrorDTO.builder()
+                .code(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
+                .message("Unexpected error")
+                .build();
+    }
 }

--- a/order/src/main/java/com/orderingsystem/order/application/exception/OrderApplicationException.java
+++ b/order/src/main/java/com/orderingsystem/order/application/exception/OrderApplicationException.java
@@ -1,7 +1,11 @@
 package com.orderingsystem.order.application.exception;
 
 public class OrderApplicationException extends RuntimeException {
-  public OrderApplicationException(String message) {
-    super(message);
-  }
+    public OrderApplicationException(String message) {
+        super(message);
+    }
+
+    public OrderApplicationException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/order/src/main/java/com/orderingsystem/order/application/outbox/payment/PaymentOutboxHelper.java
+++ b/order/src/main/java/com/orderingsystem/order/application/outbox/payment/PaymentOutboxHelper.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.saga.SagaStatus;
+import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.application.outbox.payment.model.OrderPaymentEventPayload;
 import com.orderingsystem.order.domain.exception.OrderDomainException;
 import com.orderingsystem.order.domain.model.outbox.PaymentOutbox;
@@ -30,15 +31,14 @@ public class PaymentOutboxHelper {
 
     @Transactional
     public void save(PaymentOutbox paymentOutbox) {
-        try {
+        if (!paymentOutboxRepository.existsByTypeAndSagaIdAndSagaStatusAndOutboxStatus(ORDER_SAGA_NAME,
+                paymentOutbox.getSagaId(),
+                paymentOutbox.getSagaStatus(), paymentOutbox.getOutboxStatus())) {
             paymentOutboxRepository.save(paymentOutbox);
             log.info("Order PaymentOutbox 저장했습니다. Outbox Id : {}", paymentOutbox.getId());
-        } catch (Exception e) {
-            log.error("Order PaymentOutbox 저장에 실패했습니다. Outbox Id : {}, Message : {}",
-                    paymentOutbox.getId(), e.getMessage());
-            throw new OrderDomainException(
-                    "Order PaymentOutbox 저장에 실패했습니다. Outbox Id : " + paymentOutbox.getId() +
-                            " Message : " + e.getMessage());
+        } else {
+            log.warn("이미 저장된 Order PaymentOutbox가 존재합니다. Saga Id : {}, Type : {} OrderStatus : {}",
+                    paymentOutbox.getSagaId(), paymentOutbox.getType(), paymentOutbox.getOrderStatus());
         }
     }
 
@@ -84,7 +84,8 @@ public class PaymentOutboxHelper {
 
     @Transactional
     public Optional<PaymentOutbox> getPaymentOutboxBySagaIdAndSagaStatus(UUID sagaId, SagaStatus... sagaStatus) {
-        return paymentOutboxRepository.findByTypeAndSagaIdAndSagaStatusIn(ORDER_SAGA_NAME, sagaId, Arrays.asList(sagaStatus));
+        return paymentOutboxRepository.findByTypeAndSagaIdAndSagaStatusIn(ORDER_SAGA_NAME, sagaId,
+                Arrays.asList(sagaStatus));
     }
 
     public Optional<PaymentOutbox> getPaymentOutboxBySagaIdAndSagaStatusIn(UUID sagaId, List<SagaStatus> started) {

--- a/order/src/main/java/com/orderingsystem/order/application/outbox/restaurant/RestaurantApprovalOutboxHelper.java
+++ b/order/src/main/java/com/orderingsystem/order/application/outbox/restaurant/RestaurantApprovalOutboxHelper.java
@@ -30,15 +30,15 @@ public class RestaurantApprovalOutboxHelper {
 
     @Transactional
     public void save(RestaurantApprovalOutbox restaurantApprovalOutbox) {
-        try {
+        if (!restaurantApprovalOutboxRepository.existsByTypeAndSagaIdAndOrderStatusAndSagaStatus(ORDER_SAGA_NAME,
+                restaurantApprovalOutbox.getSagaId(), restaurantApprovalOutbox.getOrderStatus(),
+                restaurantApprovalOutbox.getSagaStatus())) {
             restaurantApprovalOutboxRepository.save(restaurantApprovalOutbox);
             log.info("Order RestaurantApprovalOutbox 저장했습니다. Outbox Id : {}", restaurantApprovalOutbox.getId());
-        } catch (Exception e) {
-            log.error("Order RestaurantApprovalOutbox 저장에 실패했습니다. Outbox Id : {}, Message : {}",
-                    restaurantApprovalOutbox.getId(), e.getMessage());
-            throw new OrderDomainException(
-                    "Order RestaurantApprovalOutbox 저장에 실패했습니다. Outbox Id : " + restaurantApprovalOutbox.getId() +
-                            " Message : " + e.getMessage());
+        } else {
+            log.warn("이미 저장된 Order RestaurantApprovalOutbox가 존재합니다. sagaId : {}, type : {}, orderStatus : {}",
+                    restaurantApprovalOutbox.getSagaStatus(), restaurantApprovalOutbox.getType(),
+                    restaurantApprovalOutbox.getOrderStatus());
         }
     }
 

--- a/order/src/main/java/com/orderingsystem/order/domain/model/outbox/PaymentOutbox.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/outbox/PaymentOutbox.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -45,6 +46,9 @@ public class PaymentOutbox {
 
     @Enumerated(EnumType.STRING)
     private OutboxStatus outboxStatus;
+
+    @Version
+    private Long version;
 
     @Override
     public boolean equals(Object o) {

--- a/order/src/main/java/com/orderingsystem/order/domain/model/outbox/RestaurantApprovalOutbox.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/outbox/RestaurantApprovalOutbox.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -45,6 +46,9 @@ public class RestaurantApprovalOutbox {
 
     @Enumerated(EnumType.STRING)
     private OutboxStatus outboxStatus;
+
+    @Version
+    private Long version;
 
     @Override
     public boolean equals(Object o) {

--- a/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/PaymentOutboxRepository.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/PaymentOutboxRepository.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.order.domain.repository.outbox;
 
+import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.saga.SagaStatus;
 import com.orderingsystem.order.domain.model.outbox.PaymentOutbox;
 import com.orderingsystem.outbox.OutboxStatus;
@@ -19,4 +20,7 @@ public interface PaymentOutboxRepository extends JpaRepository<PaymentOutbox, UU
                                                        List<SagaStatus> list);
 
     Optional<PaymentOutbox> findByTypeAndSagaIdAndSagaStatusIn(String type, UUID sagaId, Collection<SagaStatus> sagaStatuses);
+
+    boolean existsByTypeAndSagaIdAndSagaStatusAndOutboxStatus(String type, UUID sagaId, SagaStatus sagaStatus, OutboxStatus outboxStatus);
+
 }

--- a/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/PaymentOutboxRepository.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/PaymentOutboxRepository.java
@@ -1,6 +1,5 @@
 package com.orderingsystem.order.domain.repository.outbox;
 
-import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.saga.SagaStatus;
 import com.orderingsystem.order.domain.model.outbox.PaymentOutbox;
 import com.orderingsystem.outbox.OutboxStatus;

--- a/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/RestaurantApprovalOutboxRepository.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/repository/outbox/RestaurantApprovalOutboxRepository.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.order.domain.repository.outbox;
 
+import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.saga.SagaStatus;
 import com.orderingsystem.order.domain.model.outbox.RestaurantApprovalOutbox;
 import com.orderingsystem.outbox.OutboxStatus;
@@ -24,4 +25,6 @@ public interface RestaurantApprovalOutboxRepository extends JpaRepository<Restau
                                                        List<SagaStatus> list);
 
     Optional<RestaurantApprovalOutbox> findByTypeAndSagaIdAndSagaStatus(String type, UUID sagaId, SagaStatus sagaStatus);
+
+    boolean existsByTypeAndSagaIdAndOrderStatusAndSagaStatus(String type, UUID sagaId, OrderStatus orderStatus, SagaStatus sagaStatus);
 }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.kafka.KafkaConsumer;
 import com.orderingsystem.order.application.OrderPaymentService;
+import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.infra.kafka.message.PaymentResponseMessage;
+import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -44,17 +48,27 @@ public class PaymentResponseKafkaListener implements KafkaConsumer<String> {
                 if (PaymentStatus.COMPLETED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                     log.info("결제 완료. order Id : {}", paymentResponseMessage.getOrderId());
                     orderPaymentService.process(paymentResponseMessage.toPaymentResponse());
-                } else if (PaymentStatus.CANCELLED.name().equals(paymentResponseMessage.getPaymentStatus())){
+                } else if (PaymentStatus.CANCELLED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                     log.info("결제 취소. order Id : {}", paymentResponseMessage.getOrderId());
                     orderPaymentService.rollback(paymentResponseMessage.toPaymentResponse());
-                } else if(PaymentStatus.FAILED.name().equals(paymentResponseMessage.getPaymentStatus())){
+                } else if (PaymentStatus.FAILED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                     log.info("결제 실패. order Id : {}", paymentResponseMessage.getOrderId());
                     orderPaymentService.rollback(paymentResponseMessage.toPaymentResponse());
                 }
             } catch (JsonProcessingException e) {
                 log.error("PaymentRequestMessage Json 파싱에 실패했습니다.");
-            } catch (Exception e) {
-                log.error("결제 요청 메시지 처리 중 오류 발생. message : {}, error : {}", message, e.getMessage());
+            } catch (OptimisticLockingFailureException e) {
+                //NO-OP
+                log.error("Caught optimistic locking exception in PaymentResponseKafkaListener");
+            } catch (DataAccessException e) {
+                Throwable root = e.getRootCause();
+                if (root instanceof SQLException sqlEx && "23000".equals(sqlEx.getSQLState())
+                        && sqlEx.getErrorCode() == 1062) {
+                    //NO-OP
+                    log.warn("유니크 제약 위반 발생. Sql Status : {}", sqlEx.getSQLState());
+                } else {
+                    throw new OrderApplicationException("DB 예외 발생", e);
+                }
             }
         });
     }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/RestaurantApprovalResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/RestaurantApprovalResponseKafkaListener.java
@@ -6,10 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.OrderApprovalStatus;
 import com.orderingsystem.kafka.KafkaConsumer;
 import com.orderingsystem.order.application.OrderRestaurantApprovalService;
+import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.infra.kafka.message.RestaurantApprovalResponseMessage;
+import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -55,6 +59,9 @@ public class RestaurantApprovalResponseKafkaListener implements KafkaConsumer<St
             } catch (JsonProcessingException e) {
                 log.error("RestaurantApprovalResponseMessage Json 프로세싱에 실패했습니다. error : {}", e.getMessage());
                 throw new RuntimeException(e);
+            } catch (OptimisticLockingFailureException e) {
+                //NO-OP
+                log.error("Caught optimistic locking exception in RestaurantApprovalResponseKafkaListener");
             }
         });
     }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/publisher/PaymentRequestKafkaPublisher.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/publisher/PaymentRequestKafkaPublisher.java
@@ -58,7 +58,6 @@ public class PaymentRequestKafkaPublisher implements PaymentRequestMessagePublis
                     orderPaymentEventPayload.getOrderId(), sagaId);
         } catch (JsonProcessingException e) {
             log.error("{} 객체 매핑에 실패했습니다. 원인: {}", paymentOutbox.getId(), e.getMessage());
-            throw new OrderDomainException(paymentOutbox.getId() + " 객체 매핑에 실패했습니다.", e);
         } catch (Exception e) {
             log.error("OrderPaymentEventPayload Kafka 전송에 실패했습니다. Order Id : {} Saga Id : {}, Error : {}",
                     orderPaymentEventPayload.getOrderId(), sagaId, e.getMessage());

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/publisher/RestaurantApprovalRequestKafkaPublisher.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/publisher/RestaurantApprovalRequestKafkaPublisher.java
@@ -62,7 +62,6 @@ public class RestaurantApprovalRequestKafkaPublisher implements RestaurantApprov
 
         } catch (JsonProcessingException e) {
             log.error("{} 객체 매핑에 실패했습니다. 원인: {}", restaurantApprovalOutbox.getId(), e.getMessage());
-            throw new OrderDomainException(restaurantApprovalOutbox.getId() + " 객체 매핑에 실패했습니다.", e);
         } catch (Exception e) {
             log.error("RestaurantApprovalEventPayload Kafka 전송에 실패했습니다. Order Id : {} Saga Id : {}, Error : {}",
                     restaurantApprovalEventPayload.getOrderId(), sagaId, e.getMessage());

--- a/payment/src/main/java/com/orderingsystem/payment/application/PaymentService.java
+++ b/payment/src/main/java/com/orderingsystem/payment/application/PaymentService.java
@@ -68,7 +68,7 @@ public class PaymentService {
                 .build();
 
         PaymentEvent paymentEvent = paymentValidateAndInitiateService.validateAndInitiate(payment, creditInfo,
-                creditHistories, failureMessages);
+                creditHistories, failureMessages, paymentRequest);
 
         persistCompleteDataBase(payment, creditEntry, creditInfo, creditHistories, failureMessages, payment.getPrice());
 

--- a/payment/src/main/java/com/orderingsystem/payment/application/exception/PaymentApplicationException.java
+++ b/payment/src/main/java/com/orderingsystem/payment/application/exception/PaymentApplicationException.java
@@ -4,4 +4,8 @@ public class PaymentApplicationException extends RuntimeException {
     public PaymentApplicationException(String message) {
         super(message);
     }
+
+    public PaymentApplicationException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/payment/src/main/java/com/orderingsystem/payment/application/outbox/OrderOutboxHelper.java
+++ b/payment/src/main/java/com/orderingsystem/payment/application/outbox/OrderOutboxHelper.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,22 +29,20 @@ public class OrderOutboxHelper {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public void updateOutboxMessage(OrderOutbox orderOutbox, OutboxStatus outboxStatus){
+    public void updateOutboxMessage(OrderOutbox orderOutbox, OutboxStatus outboxStatus) {
         orderOutbox.updateOutboxStatus(outboxStatus);
         log.info("Payment OrderOutbox Status 업데이트 : {}", outboxStatus);
     }
 
     @Transactional
-    public void save(OrderOutbox orderOutbox){
-        try {
+    public void save(OrderOutbox orderOutbox) {
+        if (!orderOutboxRepository.existsByTypeAndSagaIdAndPaymentStatusAndOutboxStatus(ORDER_SAGA_NAME,
+                orderOutbox.getSagaId(), orderOutbox.getPaymentStatus(), orderOutbox.getOutboxStatus())) {
             orderOutboxRepository.save(orderOutbox);
             log.info("Payment OrderOutbox 저장했습니다. Outbox Id : {}", orderOutbox.getId());
-        } catch (Exception e) {
-            log.error("payment OrderOutbox 저장에 실패했습니다. Outbox Id : {}, Message : {}",
-                    orderOutbox.getId(), e.getMessage());
-            throw new PaymentDomainException(
-                    "payment OrderOutbox 저장에 실패했습니다. Outbox Id : " + orderOutbox.getId() +
-                            " Message : " + e.getMessage());
+        } else {
+            log.warn("이미 저장된 Payment OrderOutbox가 존재합니다. Saga Id : {}, Type : {}, PaymentStatus : {}",
+                    orderOutbox.getSagaId(), orderOutbox.getType(), orderOutbox.getPaymentStatus());
         }
     }
 

--- a/payment/src/main/java/com/orderingsystem/payment/domain/model/CreditHistory.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/model/CreditHistory.java
@@ -41,6 +41,8 @@ public class CreditHistory {
 
     private ZonedDateTime paidAt;
 
+    private UUID orderId;
+
     @PrePersist
     protected void onCreate() {
         this.paidAt = ZonedDateTime.now();

--- a/payment/src/main/java/com/orderingsystem/payment/domain/model/outbox/OrderOutbox.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/model/outbox/OrderOutbox.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -41,6 +42,9 @@ public class OrderOutbox {
 
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
+
+    @Version
+    private Long version;
 
     @Override
     public boolean equals(Object o) {

--- a/payment/src/main/java/com/orderingsystem/payment/domain/repository/outbox/OrderOutboxRepository.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/repository/outbox/OrderOutboxRepository.java
@@ -18,4 +18,6 @@ public interface OrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> 
     Optional<List<OrderOutbox>> findByTypeAndOutboxStatus(String orderSagaName, OutboxStatus outboxStatus);
 
     void deleteAllByTypeAndOutboxStatus(String orderSagaName, OutboxStatus outboxStatus);
+
+    boolean existsByTypeAndSagaIdAndPaymentStatusAndOutboxStatus(String type, UUID sagaId, PaymentStatus paymentStatus, OutboxStatus outboxStatus);
 }

--- a/payment/src/main/java/com/orderingsystem/payment/domain/service/PaymentValidateAndInitiateService.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/service/PaymentValidateAndInitiateService.java
@@ -1,12 +1,11 @@
 package com.orderingsystem.payment.domain.service;
 
 import com.orderingsystem.common.domain.Money;
-import com.orderingsystem.common.domain.publisher.DomainEventPublisher;
 import com.orderingsystem.common.domain.status.PaymentStatus;
+import com.orderingsystem.payment.application.dto.request.PaymentRequest;
 import com.orderingsystem.payment.domain.event.PaymentCompletedEvent;
 import com.orderingsystem.payment.domain.event.PaymentEvent;
 import com.orderingsystem.payment.domain.event.PaymentFailedEvent;
-import com.orderingsystem.payment.domain.model.CreditEntry;
 import com.orderingsystem.payment.domain.model.CreditHistory;
 import com.orderingsystem.payment.domain.model.CreditInfo;
 import com.orderingsystem.payment.domain.model.Payment;
@@ -25,14 +24,14 @@ public class PaymentValidateAndInitiateService {
 
     public PaymentEvent validateAndInitiate(Payment payment, CreditInfo creditInfo,
                                             List<CreditHistory> creditHistories,
-                                            List<String> failureMessages) {
+                                            List<String> failureMessages, PaymentRequest paymentRequest) {
 
         payment.validatePayment(failureMessages);
         payment.initializePayment();
 
         validateCreditEntry(payment, creditInfo, failureMessages);
         subtractCreditEntry(payment, creditInfo);
-        updateCreditHistory(payment, creditHistories, TransactionType.DEBIT);
+        updateCreditHistory(payment, creditHistories, TransactionType.DEBIT, paymentRequest);
         validateCreditHistory(creditInfo, creditHistories, failureMessages);
 
         if (failureMessages.isEmpty()) {
@@ -58,12 +57,13 @@ public class PaymentValidateAndInitiateService {
     }
 
     private void updateCreditHistory(Payment payment, List<CreditHistory> creditHistories,
-                                     TransactionType transactionType) {
+                                     TransactionType transactionType, PaymentRequest paymentRequest) {
         creditHistories.add(CreditHistory.builder()
                 .id(UUID.randomUUID())
                 .customerId(payment.getCustomerId())
                 .amount(payment.getPrice())
                 .type(transactionType)
+                .orderId(paymentRequest.getOrderId())
                 .build());
     }
 

--- a/payment/src/main/java/com/orderingsystem/payment/infra/kafka/listener/PaymentRequestKafkaListener.java
+++ b/payment/src/main/java/com/orderingsystem/payment/infra/kafka/listener/PaymentRequestKafkaListener.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.PaymentOrderStatus;
 import com.orderingsystem.kafka.KafkaConsumer;
 import com.orderingsystem.payment.application.PaymentService;
+import com.orderingsystem.payment.application.exception.PaymentApplicationException;
 import com.orderingsystem.payment.infra.kafka.message.PaymentRequestMessage;
+import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -43,15 +47,25 @@ public class PaymentRequestKafkaListener implements KafkaConsumer<String> {
                 if (PaymentOrderStatus.PENDING.equals(paymentRequestMessage.getPaymentOrderStatus())) {
                     log.info("결제 진행. order Id : {}", paymentRequestMessage.getOrderId());
                     paymentService.completePayment(paymentRequestMessage.toPaymentRequest());
-                } else if (PaymentOrderStatus.CANCELLED.equals(paymentRequestMessage.getPaymentOrderStatus())){
+                } else if (PaymentOrderStatus.CANCELLED.equals(paymentRequestMessage.getPaymentOrderStatus())) {
                     log.info("결제 취소 진행. order Id : {}", paymentRequestMessage.getOrderId());
                     paymentService.cancelPayment(paymentRequestMessage.toPaymentRequest());
                 }
 
             } catch (JsonProcessingException e) {
                 log.error("PaymentRequestMessage Json 파싱에 실패했습니다.");
-            } catch (Exception e) {
-                log.error("결제 요청 메시지 처리 중 오류 발생. message : {}, error : {}", message, e.getMessage());
+            } catch (OptimisticLockingFailureException e) {
+                //NO-OP
+                log.error("Caught optimistic locking exception in RestaurantApprovalResponseKafkaListener");
+            } catch (DataAccessException e) {
+                Throwable root = e.getRootCause();
+                if (root instanceof SQLException sqlEx && "23000".equals(sqlEx.getSQLState())
+                        && sqlEx.getErrorCode() == 1062) {
+                    //NO-OP
+                    log.warn("유니크 제약 위반 발생. Sql Status : {}", sqlEx.getSQLState());
+                } else {
+                    throw new PaymentApplicationException("DB 예외 발생", e);
+                }
             }
         });
     }

--- a/payment/src/main/java/com/orderingsystem/payment/infra/kafka/publisher/PaymentResponseKafkaPublisher.java
+++ b/payment/src/main/java/com/orderingsystem/payment/infra/kafka/publisher/PaymentResponseKafkaPublisher.java
@@ -58,13 +58,9 @@ public class PaymentResponseKafkaPublisher implements PaymentResponseMessagePubl
 
         } catch (JsonProcessingException e) {
             log.error("{} 객체 매핑에 실패했습니다. 원인: {}", orderOutbox.getId(), e.getMessage());
-            throw new RuntimeException(orderOutbox.getId() + " 객체 매핑에 실패했습니다.", e);
         } catch (Exception e) {
             log.error("OrderPaymentEventPayload Kafka 전송에 실패했습니다. Order Id : {} Saga Id : {}, Error : {}",
                     orderEventPayload.getOrderId(), sagaId, e.getMessage());
-            throw new RuntimeException(
-                    "OrderPaymentEventPayload Kafka 전송에 실패했습니다. Order Id : " + orderEventPayload.getOrderId()
-                            + " Saga Id : " + sagaId + ", Error : " + e.getMessage());
         }
     }
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/application/RestaurantService.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/application/RestaurantService.java
@@ -10,6 +10,7 @@ import com.orderingsystem.restaurant.application.mapper.RestaurantDataMapper;
 import com.orderingsystem.restaurant.application.outbox.OrderOutboxHelper;
 import com.orderingsystem.restaurant.domain.event.OrderApprovalEvent;
 import com.orderingsystem.restaurant.domain.exception.RestaurantNotFoundException;
+import com.orderingsystem.restaurant.domain.model.OrderApproval;
 import com.orderingsystem.restaurant.domain.model.OrderDetail;
 import com.orderingsystem.restaurant.domain.model.Product;
 import com.orderingsystem.restaurant.domain.model.Restaurant;
@@ -58,7 +59,7 @@ public class RestaurantService {
         OrderApprovalEvent orderApprovalEvent =
                 restaurantValidateOrderService.validateOrder(restaurantInfo, failureMessage);
 
-        orderApprovalRepository.save(restaurantInfo.getOrderApproval());
+        orderApprovalSave(restaurantInfo.getOrderApproval());
 
         orderOutboxHelper.saveOrderOutboxMessage(
                 restaurantDataMapper.restaurantApprovalEventToOrderEventPayload(orderApprovalEvent),
@@ -130,5 +131,12 @@ public class RestaurantService {
         });
 
         return restaurant;
+    }
+
+    private void orderApprovalSave(OrderApproval orderApproval) {
+        if (!orderApprovalRepository.existsByOrderIdAndRestaurantIdAndStatus(orderApproval.getOrderId(),
+                orderApproval.getRestaurantId(), orderApproval.getStatus())){
+            orderApprovalRepository.save(orderApproval);
+        }
     }
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/application/exception/RestaurantApplicationException.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/application/exception/RestaurantApplicationException.java
@@ -4,4 +4,8 @@ public class RestaurantApplicationException extends RuntimeException {
     public RestaurantApplicationException(String message) {
         super(message);
     }
+
+    public RestaurantApplicationException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/application/outbox/OrderOutboxHelper.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/application/outbox/OrderOutboxHelper.java
@@ -30,15 +30,13 @@ public class OrderOutboxHelper {
 
     @Transactional
     public void save(OrderOutbox orderOutbox) {
-        try {
+        if (!orderOutboxRepository.existsByTypeAndSagaIdAndOrderApprovalStatusAndOutboxStatus(ORDER_SAGA_NAME,
+                orderOutbox.getSagaId(), orderOutbox.getOrderApprovalStatus(), orderOutbox.getOutboxStatus())) {
             orderOutboxRepository.save(orderOutbox);
             log.info("Restaurant OrderOutbox 저장했습니다. Outbox Id : {}", orderOutbox.getId());
-        } catch (Exception e) {
-            log.error("Restaurant OrderOutbox 저장에 실패했습니다. Outbox Id : {}, Message : {}",
-                    orderOutbox.getId(), e.getMessage());
-            throw new RestaurantDomainException(
-                    "Restaurant OrderOutbox 저장에 실패했습니다. Outbox Id : " + orderOutbox.getId() +
-                            " Message : " + e.getMessage());
+        } else {
+            log.warn("이미 저장된 Restaurant OrderOutbox가 존재합니다. Saga Id : {}, Type : {}, ApprovalStatus : {}",
+                    orderOutbox.getSagaId(), orderOutbox.getType(), orderOutbox.getOrderApprovalStatus());
         }
     }
 

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/domain/model/outbox/OrderOutbox.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/domain/model/outbox/OrderOutbox.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -41,6 +42,9 @@ public class OrderOutbox {
 
     @Enumerated(EnumType.STRING)
     private OrderApprovalStatus orderApprovalStatus;
+
+    @Version
+    private Long version;
 
     @Override
     public boolean equals(Object o) {

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/OrderApprovalRepository.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/OrderApprovalRepository.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.restaurant.domain.repository;
 
+import com.orderingsystem.common.domain.status.OrderApprovalStatus;
 import com.orderingsystem.restaurant.domain.model.OrderApproval;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderApprovalRepository extends JpaRepository<OrderApproval, UUID> {
+    boolean existsByOrderIdAndRestaurantIdAndStatus(UUID orderId, UUID restaurantId, OrderApprovalStatus status);
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/outbox/OrderOutboxRepository.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/domain/repository/outbox/OrderOutboxRepository.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.restaurant.domain.repository.outbox;
 
+import com.orderingsystem.common.domain.status.OrderApprovalStatus;
 import com.orderingsystem.outbox.OutboxStatus;
 import com.orderingsystem.restaurant.domain.model.outbox.OrderOutbox;
 import java.util.List;
@@ -16,4 +17,6 @@ public interface OrderOutboxRepository extends JpaRepository<OrderOutbox, UUID> 
     Optional<List<OrderOutbox>> findByTypeAndOutboxStatus(String orderSagaName, OutboxStatus outboxStatus);
 
     void deleteAllByTypeAndOutboxStatus(String orderSagaName, OutboxStatus outboxStatus);
+
+    boolean existsByTypeAndSagaIdAndOrderApprovalStatusAndOutboxStatus(String type, UUID sagaId, OrderApprovalStatus orderApprovalStatus, OutboxStatus outboxStatus);
 }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/infra/kafka/listener/RestaurantApprovalRequestKafkaListener.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/infra/kafka/listener/RestaurantApprovalRequestKafkaListener.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.kafka.KafkaConsumer;
 import com.orderingsystem.restaurant.application.RestaurantService;
+import com.orderingsystem.restaurant.application.exception.RestaurantApplicationException;
 import com.orderingsystem.restaurant.infra.kafka.message.RestaurantApprovalRequestMessage;
+import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -24,8 +28,8 @@ public class RestaurantApprovalRequestKafkaListener implements KafkaConsumer<Str
     private final RestaurantService restaurantService;
 
     @Override
-    @KafkaListener(id="${kafka-consumer-config.restaurant-consumer-group-id}",
-    topics = "${restaurant-topic.restaurant-approval-request-topic-name}")
+    @KafkaListener(id = "${kafka-consumer-config.restaurant-consumer-group-id}",
+            topics = "${restaurant-topic.restaurant-approval-request-topic-name}")
     public void receive(@Payload List<String> messages,
                         @Header(KafkaHeaders.RECEIVED_KEY) List<String> keys,
                         @Header(KafkaHeaders.RECEIVED_PARTITION) List<Integer> partitions,
@@ -34,7 +38,7 @@ public class RestaurantApprovalRequestKafkaListener implements KafkaConsumer<Str
                 messages.size(), keys.toString(), partitions.toString(), offsets.toString());
 
         messages.forEach(message -> {
-            try{
+            try {
                 RestaurantApprovalRequestMessage requestMessage =
                         objectMapper.readValue(message, RestaurantApprovalRequestMessage.class);
 
@@ -47,6 +51,18 @@ public class RestaurantApprovalRequestKafkaListener implements KafkaConsumer<Str
             } catch (JsonProcessingException e) {
                 log.info("Json 프로세싱에 실패했습니다. error : {}", e.getMessage());
                 throw new RuntimeException(e);
+            } catch (OptimisticLockingFailureException e) {
+                //NO-OP
+                log.error("Caught optimistic locking exception in RestaurantApprovalResponseKafkaListener");
+            } catch (DataAccessException e) {
+                Throwable root = e.getRootCause();
+                if (root instanceof SQLException sqlEx && "23000".equals(sqlEx.getSQLState())
+                        && sqlEx.getErrorCode() == 1062) {
+                    //NO-OP
+                    log.warn("유니크 제약 위반 발생. Sql Status : {}", sqlEx.getSQLState());
+                } else {
+                    throw new RestaurantApplicationException("DB 예외 발생", e);
+                }
             }
         });
     }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/infra/kafka/publisher/RestaurantApprovalResponseKafkaPublisher.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/infra/kafka/publisher/RestaurantApprovalResponseKafkaPublisher.java
@@ -58,12 +58,9 @@ public class RestaurantApprovalResponseKafkaPublisher implements RestaurantAppro
 
         } catch (JsonProcessingException e) {
             log.error("{} 객체 매핑에 실패했습니다. 원인: {}", orderOutbox.getId(), e.getMessage());
-            throw new RuntimeException(orderOutbox.getId() + " 객체 매핑에 실패했습니다.", e);
         } catch (Exception e) {
             log.error("OrderEventPayload Kafka 전송에 실패했습니다. Order Id : {} Saga Id : {}, Error : {}",
                     orderEventPayload.getOrderId(), sagaId, e.getMessage());
-            throw new RuntimeException("OrderEventPayload Kafka 전송에 실패했습니다. Order Id : "
-                    + orderEventPayload.getOrderId() + " Saga Id : " + sagaId + ", Error : " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #17 

## 📝작업 내용

### 1. outbox 재처리 방지
- outbox 테이블 유니크 인덱스 추가
  - `order.restaurant_approval_outbox (type, saga_id, order_status, saga_status)`
  - `order.payment_outbox(type, saga_id, order_status, saga_status)`
  - `payment.order_outbox(type, saga_id, payment_status, outbox_status)`
  - `restaurant.order_outbox(type, saga_id, order_approval_status, outbox_status)`
- outbox 메시지 저장 시 exists 체크 로직 선행
- KafkaListener에서 `OptimisticLockingFailureException`, `DataAccessException` NO-OP 처리로 재처리 방지

### 2. Outbox 낙관적 락 적용
- 메시지 갱신 시점에서만 충돌 발생 가능 → 낙관적 락으로 대응
- 충돌 발생 시 재시도 전략 사용 가능
- 직렬화 성능 저하를 고려해 비관적 락은 사용하지 않음

### 3. Kafka Publisher에서 Exception Throw 삭제
- Kafka send() 실패 시 Exception throw 제거
- 전송 실패는 OutboxStatus 기반으로 scheduler가 재처리

### 4. CreditHistory 테이블에 Order Id 추가로 저장하도록 변경
- 결제 추적성 향상을 위해 order_id 필드 추가