### PR TITLE
[Fix] #23 상품의 가격이 일치하지 않거나 상품이 판매할 수 없는 상태일 경우 주문 생성 후 주문이 취소되도록 변경

### DIFF
--- a/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.orderingsystem.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -31,5 +32,16 @@ public class GlobalExceptionHandler {
                 .code(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
                 .message("Unexpected error")
                 .build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorDTO> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error(e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .message("Unexpected error")
+                        .build());
     }
 }

--- a/order/src/main/java/com/orderingsystem/order/application/OrderCreateHelper.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderCreateHelper.java
@@ -12,6 +12,7 @@ import com.orderingsystem.order.domain.repository.CustomerRepository;
 import com.orderingsystem.order.domain.repository.OrderAddressRepository;
 import com.orderingsystem.order.domain.repository.OrderRepository;
 import com.orderingsystem.order.domain.service.OrderValidateAndInitiateService;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,19 +32,22 @@ public class OrderCreateHelper {
     private final OrderAddressRepository orderAddressRepository;
 
     @Transactional
-    public OrderCreateEvent persistOrder(CreateOrderApplicationRequest createOrderRequest, RestaurantInfo restaurantInfo) {
+    public OrderCreateEvent persistOrder(CreateOrderApplicationRequest createOrderRequest,
+                                         RestaurantInfo restaurantInfo, List<String> failureMessages) {
         checkCustomer(createOrderRequest.getCustomerId());
 
         OrderAddress orderAddress = orderDataMapper.orderAddressToStreetAddress(createOrderRequest.getAddress());
         Order order = orderDataMapper.createOrderRequestToOrder(createOrderRequest, orderAddress.getId());
 
         OrderCreateEvent orderCreateEvent =
-                orderValidateAndInitiateService.validateAndInitiate(order, restaurantInfo.toRestaurant());
+                orderValidateAndInitiateService.validateAndInitiate(
+                        order, restaurantInfo.toRestaurant(), failureMessages);
 
         Order savedOrder = saveOrder(order);
         saveOrderAddress(orderAddress, order);
 
         log.info("주문이 생성되었습니다. Order Id : {}", savedOrder.getId());
+
         return orderCreateEvent;
     }
 
@@ -70,7 +74,7 @@ public class OrderCreateHelper {
         try {
             orderAddress.updateOrderId(order.getId());
             orderAddressRepository.save(orderAddress);
-        } catch (Exception e){
+        } catch (Exception e) {
             log.warn("주문 주소가 저장되지 않았습니다.");
             throw new OrderDomainException("주문 주소가 저장되지 않았습니다.");
         }

--- a/order/src/main/java/com/orderingsystem/order/application/OrderService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderService.java
@@ -11,6 +11,8 @@ import com.orderingsystem.order.domain.exception.OrderNotFoundException;
 import com.orderingsystem.order.domain.model.Order;
 import com.orderingsystem.order.domain.repository.OrderRepository;
 import com.orderingsystem.outbox.OutboxStatus;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,22 +33,35 @@ public class OrderService {
 
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderApplicationRequest createOrderRequest) {
+        List<String> failureMessages = new ArrayList<>();
+
         RestaurantInfo restaurantInfo = restaurantApi.getRestaurantInfo(createOrderRequest.getRestaurantId(),
                 orderDataMapper.itemsToItemIdList(createOrderRequest.getItems()));
 
-        OrderCreateEvent orderCreateEvent = orderCreateHelper.persistOrder(createOrderRequest, restaurantInfo);
+        OrderCreateEvent orderCreateEvent = orderCreateHelper.persistOrder(createOrderRequest, restaurantInfo,
+                failureMessages);
         log.info("주문이 생성되었습니다. Order Id : {}", orderCreateEvent.getOrder().getId());
 
-        UUID sagaId = UUID.randomUUID();
-        paymentOutboxHelper.savePaymentOutboxMessage(
-                orderDataMapper.orderCreatedToOrderPaymentEventPayload(orderCreateEvent, sagaId),
-                orderCreateEvent.getOrder().getOrderStatus(),
-                OrderStatusToSagaStatus.orderStatusToSagaStatus(orderCreateEvent.getOrder().getOrderStatus()),
-                OutboxStatus.STARTED,
-                sagaId
-        );
+        String resultMessage = "주문이 성공적으로 생성되었습니다.";
 
-        return orderDataMapper.orderToCreateOrderResponse(orderCreateEvent.getOrder(), "주문이 성공적으로 생성되었습니다.");
+        if (!failureMessages.isEmpty()) {
+            log.warn("주문이 취소되었습니다. Order Id : {}", orderCreateEvent.getOrder().getId());
+            Order order = orderCreateEvent.getOrder();
+            order.cancel(failureMessages);
+            orderRepository.save(order);
+            resultMessage = "주문 요청이 유효하지 않아 주문이 완료되지 않았습니다.";
+        } else {
+            UUID sagaId = UUID.randomUUID();
+            paymentOutboxHelper.savePaymentOutboxMessage(
+                    orderDataMapper.orderCreatedToOrderPaymentEventPayload(orderCreateEvent, sagaId),
+                    orderCreateEvent.getOrder().getOrderStatus(),
+                    OrderStatusToSagaStatus.orderStatusToSagaStatus(orderCreateEvent.getOrder().getOrderStatus()),
+                    OutboxStatus.STARTED,
+                    sagaId
+            );
+        }
+
+        return orderDataMapper.orderToCreateOrderResponse(orderCreateEvent.getOrder(), resultMessage);
     }
 
     @Transactional(readOnly = true)

--- a/order/src/main/java/com/orderingsystem/order/application/dto/ProductInfo.java
+++ b/order/src/main/java/com/orderingsystem/order/application/dto/ProductInfo.java
@@ -16,5 +16,6 @@ public class ProductInfo {
     private UUID productId;
     private String name;
     private BigDecimal price;
+    private boolean available;
 
 }

--- a/order/src/main/java/com/orderingsystem/order/application/dto/RestaurantInfo.java
+++ b/order/src/main/java/com/orderingsystem/order/application/dto/RestaurantInfo.java
@@ -29,6 +29,7 @@ public class RestaurantInfo {
                                         .productId(product.getProductId())
                                         .name(product.getName())
                                         .price(new Money(product.getPrice()))
+                                        .available(product.isAvailable())
                                         .build())
                         .toList())
                 .build();

--- a/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
@@ -23,6 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Table(name = "orders")
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public class Order extends AggregateRoot {
 
     @Id
@@ -89,10 +91,10 @@ public class Order extends AggregateRoot {
         }
     }
 
-    public void validateOrder() {
+    public void validateOrder(List<String> failureMessages) {
         validateInitialOrder();
-        validateTotalPrice();
-        validateItemsPrice();
+        validateTotalPrice(failureMessages);
+        validateItems(failureMessages);
     }
 
     private void validateInitialOrder() {
@@ -101,28 +103,42 @@ public class Order extends AggregateRoot {
         }
     }
 
-    private void validateTotalPrice() {
+    private void validateTotalPrice(List<String> failureMessages) {
         if (price == null || !price.isGreaterThanZero()) {
-            throw new OrderDomainException("총 주문 금액은 0보다 커야합니다.");
+            log.warn("총 주문 금액은 0보다 커야합니다. Order Id : {}", this.id);
+            failureMessages.add("총 주문 금액은 0보다 커야합니다.");
         }
     }
 
-    private void validateItemsPrice() {
+    private void validateItems(List<String> failureMessages) {
         Money orderItemsTotal = items.stream().map(orderItem -> {
-            validateItemPrice(orderItem);
+            validateItemPrice(orderItem, failureMessages);
+            validateItemAvailability(orderItem, failureMessages);
             return orderItem.getSubTotal();
         }).reduce(Money.ZERO, Money::add);
 
         if (!price.equals(orderItemsTotal)) {
-            throw new OrderDomainException("총 주문 금액 : " + price.getAmount()
-                    + " 개별 항목들의 합계 : " + orderItemsTotal.getAmount() + " 총 주문 금액과 개별 항목들의 합계가 일치하지 않습니다.");
+            log.warn("총 주문 금액 : {} 개별 항목들의 합계 : {}. 총 주문 금액과 개별 항목들의 합계가 일치하지 않습니다. Order Id : {}", price.getAmount(),
+                    orderItemsTotal.getAmount(), this.id);
+            failureMessages.add("총 주문 금액 : " + price.getAmount()
+                    + " 개별 항목들의 합계 : " + orderItemsTotal.getAmount() + ". 총 주문 금액과 개별 항목들의 합계가 일치하지 않습니다.");
         }
     }
 
-    private void validateItemPrice(OrderItem orderItem) {
+    private void validateItemPrice(OrderItem orderItem, List<String> failureMessages) {
         if (!orderItem.isPriceValid()) {
-            throw new OrderDomainException("상품: " + orderItem.getProduct().getProductId() +
+            log.warn("상품 : {}의 항목 가격 : {}이 유효하지 않습니다. Order Id : {}", orderItem.getProduct().getProductId(),
+                    orderItem.getProduct().getPrice().getAmount(), this.id);
+            failureMessages.add("상품 : " + orderItem.getProduct().getProductId() +
                     "의 항목 가격 : " + orderItem.getProduct().getPrice().getAmount() + "이 유효하지 않습니다.");
+        }
+    }
+
+    private void validateItemAvailability(OrderItem orderItem, List<String> failureMessages) {
+        if (!orderItem.getProduct().isAvailable()) {
+            log.warn("상품 : {}이 판매할 수 없는 상태입니다. Order Id : {}", orderItem.getProduct().getProductId(),
+                    orderItem.getOrder().getId());
+            failureMessages.add("상품 : " + orderItem.getProduct().getProductId() + "이 판매할 수 없는 상태입니다.");
         }
     }
 
@@ -171,8 +187,8 @@ public class Order extends AggregateRoot {
         }
     }
 
-    public void updateItems(List<OrderItem> items){
-        this.items=items;
+    public void updateItems(List<OrderItem> items) {
+        this.items = items;
     }
 
 }

--- a/order/src/main/java/com/orderingsystem/order/domain/model/Product.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/Product.java
@@ -16,10 +16,12 @@ public class Product {
     private UUID productId;
     private String name;
     private Money price;
+    private boolean available;
 
-    public void updateWithConfirmedNameAndPrice(String name, Money price) {
+    public void updateWithConfirmedNameAndPrice(String name, Money price, boolean available) {
         this.name = name;
         this.price = price;
+        this.available = available;
     }
 
     public Product(UUID productId) {

--- a/order/src/main/java/com/orderingsystem/order/domain/service/OrderValidateAndInitiateService.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/service/OrderValidateAndInitiateService.java
@@ -1,7 +1,6 @@
 package com.orderingsystem.order.domain.service;
 
 import com.orderingsystem.order.domain.event.OrderCreateEvent;
-import com.orderingsystem.order.domain.exception.OrderDomainException;
 import com.orderingsystem.order.domain.model.Order;
 import com.orderingsystem.order.domain.model.OrderItem;
 import com.orderingsystem.order.domain.model.Product;
@@ -15,18 +14,22 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderValidateAndInitiateService {
 
-    public OrderCreateEvent validateAndInitiate(Order order, Restaurant restaurant) {
-        validateRestaurant(restaurant);
+    public OrderCreateEvent validateAndInitiate(Order order, Restaurant restaurant,
+                                                          List<String> failureMessages) {
+        validateRestaurant(restaurant, failureMessages);
         setOrderProductInformation(order, restaurant);
-        order.validateOrder();
+        order.validateOrder(failureMessages);
         order.initializeOrder();
-        log.info("주문 생성. Order ID : {}", order.getId());
+
+        log.info("주문 생성. Order Id : {}", order.getId());
+
         return new OrderCreateEvent(order, ZonedDateTime.now());
     }
 
-    private void validateRestaurant(Restaurant restaurant) {
+    private void validateRestaurant(Restaurant restaurant, List<String> failureMessages) {
         if (!restaurant.isActive()) {
-            throw new OrderDomainException("restaurant Id : " + restaurant.getRestaurantId() + " active 상태가 아닙니다.");
+            log.warn("restaurant Id : {} active 상태가 아닙니다.", restaurant.getRestaurantId());
+            failureMessages.add("restaurant Id : " + restaurant.getRestaurantId() + " active 상태가 아닙니다.");
         }
     }
 
@@ -40,7 +43,7 @@ public class OrderValidateAndInitiateService {
             for (Product restaurantProduct : restaurantProducts) {
                 if (currentProduct.equals(restaurantProduct)) {
                     currentProduct.updateWithConfirmedNameAndPrice(restaurantProduct.getName(),
-                            restaurantProduct.getPrice());
+                            restaurantProduct.getPrice(), restaurantProduct.isAvailable());
                     break;
                 }
             }

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/application/dto/response/ProductInfoResponse.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/application/dto/response/ProductInfoResponse.java
@@ -14,6 +14,6 @@ public class ProductInfoResponse {
     private UUID productId;
     private String name;
     private BigDecimal price;
-    private boolean active;
+    private boolean available;
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23

## 📝작업 내용

> 1. 상품의 가격이 일치하지 않거나 상품이 판매할 수 없는 상태일 경우 
> 기존 500 에러 ->  주문 생성 후 주문이 취소되도록 변경
> 
> 2. 상품이 판매 가능한 상태인지 주문 생성 할 때 검증 하도록 변경
