### PR TITLE
[Fix] #47 레스토랑 주문 거절

### DIFF
--- a/common/src/main/java/com/orderingsystem/common/domain/status/OrderStatus.java
+++ b/common/src/main/java/com/orderingsystem/common/domain/status/OrderStatus.java
@@ -1,5 +1,5 @@
 package com.orderingsystem.common.domain.status;
 
 public enum OrderStatus {
-    PENDING, PAID, ACCEPTED, APPROVED, CANCELLING, CANCELLED
+    PENDING, PAID, ACCEPTED, APPROVED, REJECTED, REJECTING, CANCELLING, CANCELLED
 }

--- a/common/src/main/java/com/orderingsystem/common/domain/status/PaymentStatus.java
+++ b/common/src/main/java/com/orderingsystem/common/domain/status/PaymentStatus.java
@@ -1,5 +1,5 @@
 package com.orderingsystem.common.domain.status;
 
 public enum PaymentStatus {
-    COMPLETED, CANCELLED, FAILED
+    COMPLETED, CANCELLED, FAILED, REFUNDED
 }

--- a/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
@@ -147,7 +147,7 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
     private SagaStatus[] getCurrentSagaStatus(PaymentStatus paymentStatus) {
         return switch (paymentStatus) {
             case COMPLETED -> new SagaStatus[]{SagaStatus.STARTED};
-            case CANCELLED -> new SagaStatus[]{SagaStatus.PROCESSING, SagaStatus.COMPENSATING};
+            case CANCELLED, REFUNDED -> new SagaStatus[]{SagaStatus.PROCESSING, SagaStatus.COMPENSATING};
             case FAILED -> new SagaStatus[]{SagaStatus.STARTED, SagaStatus.PROCESSING};
         };
     }

--- a/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderRestaurantApprovalService.java
@@ -1,6 +1,11 @@
 package com.orderingsystem.order.application;
 
+import com.orderingsystem.common.saga.SagaStatus;
+import com.orderingsystem.order.application.dto.response.PaymentResponse;
 import com.orderingsystem.order.application.dto.response.RestaurantOrderDecisionResponse;
+import com.orderingsystem.order.application.mapper.OrderDataMapper;
+import com.orderingsystem.order.application.outbox.payment.PaymentOutboxHelper;
+import com.orderingsystem.order.domain.event.OrderRejectedEvent;
 import com.orderingsystem.order.domain.exception.OrderNotFoundException;
 import com.orderingsystem.order.domain.model.Order;
 import com.orderingsystem.order.domain.model.outbox.MessageType;
@@ -21,17 +26,49 @@ public class OrderRestaurantApprovalService {
 
     private final OrderRepository orderRepository;
     private final ProcessedMessageRepository processedMessageRepository;
+    private final PaymentOutboxHelper paymentOutboxHelper;
+    private final OrderDataMapper orderDataMapper;
 
     @Transactional
-    public void approve(RestaurantOrderDecisionResponse restaurantOrderDecisionResponse) {
-        if (checkAndMarkProcessed(restaurantOrderDecisionResponse, MessageType.RESTAURANT_APPROVAL)) {
+    public void approve(RestaurantOrderDecisionResponse response) {
+        if (checkAndMarkProcessed(response, MessageType.RESTAURANT_APPROVAL)) {
             return;
         }
 
-        Order order = findOrder(restaurantOrderDecisionResponse.getOrderId());
+        Order order = findOrder(response.getOrderId());
         order.approve();
 
-        log.info("주문이 승인되었습니다. Order Id : {}", restaurantOrderDecisionResponse.getOrderId());
+        log.info("주문이 승인되었습니다. Order Id : {}", response.getOrderId());
+    }
+
+    @Transactional
+    public void rejecting(RestaurantOrderDecisionResponse response) {
+        log.info("레스토랑 주문 거절 처리 시작. Order Id : {}", response.getOrderId());
+        if (checkAndMarkProcessed(response, MessageType.RESTAURANT_REJECT)) {
+            return;
+        }
+
+        Order order = findOrder(response.getOrderId());
+        OrderRejectedEvent orderRejectedEvent = order.rejecting();
+
+        SagaStatus sagaStatus = OrderStatusToSagaStatus.orderStatusToSagaStatus(orderRejectedEvent.getOrder()
+                .getOrderStatus());
+
+        paymentOutboxHelper.savePaymentOutboxMessage(
+                orderDataMapper.orderRejectedEventToOrderPaymentEventPayload(orderRejectedEvent, response.getSagaId()),
+                orderRejectedEvent.getOrder().getOrderStatus(),
+                sagaStatus,
+                response.getSagaId()
+        );
+
+        log.info("레스토랑 거절로 인해 주문을 rejecting 처리했습니다. order Id : {}", orderRejectedEvent.getOrder().getId());
+    }
+
+    @Transactional
+    public void reject(PaymentResponse response) {
+        Order order = findOrder(response.getOrderId());
+        order.reject();
+        log.info("주문 reject 처리 완료. orderId : {}", response.getOrderId());
     }
 
     private boolean checkAndMarkProcessed(RestaurantOrderDecisionResponse restaurantOrderDecisionResponse,

--- a/order/src/main/java/com/orderingsystem/order/application/OrderStatusToSagaStatus.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderStatusToSagaStatus.java
@@ -11,8 +11,8 @@ public class OrderStatusToSagaStatus {
         return switch (orderStatus) {
             case PAID, ACCEPTED -> SagaStatus.PROCESSING;
             case APPROVED -> SagaStatus.SUCCEEDED;
-            case CANCELLING -> SagaStatus.COMPENSATING;
-            case CANCELLED -> SagaStatus.COMPENSATED;
+            case CANCELLING, REJECTING -> SagaStatus.COMPENSATING;
+            case CANCELLED, REJECTED -> SagaStatus.COMPENSATED;
             default -> SagaStatus.STARTED;
         };
     }

--- a/order/src/main/java/com/orderingsystem/order/application/mapper/OrderDataMapper.java
+++ b/order/src/main/java/com/orderingsystem/order/application/mapper/OrderDataMapper.java
@@ -15,6 +15,7 @@ import com.orderingsystem.order.application.outbox.restaurant.model.RestaurantAp
 import com.orderingsystem.order.domain.event.OrderCancelledEvent;
 import com.orderingsystem.order.domain.event.OrderCreateEvent;
 import com.orderingsystem.order.domain.event.OrderPaidEvent;
+import com.orderingsystem.order.domain.event.OrderRejectedEvent;
 import com.orderingsystem.order.domain.model.Order;
 import com.orderingsystem.order.domain.model.OrderAddress;
 import com.orderingsystem.order.domain.model.OrderItem;
@@ -132,4 +133,15 @@ public class OrderDataMapper {
                 .build();
     }
 
+    public OrderPaymentEventPayload orderRejectedEventToOrderPaymentEventPayload(OrderRejectedEvent orderRejectedEvent, UUID sagaId) {
+        return OrderPaymentEventPayload.builder()
+                .orderId(orderRejectedEvent.getOrder().getId().toString())
+                .sagaId(sagaId.toString())
+                .customerId(orderRejectedEvent.getOrder().getCustomerId().toString())
+                .price(orderRejectedEvent.getOrder().getPrice().getAmount())
+                .createdAt(orderRejectedEvent.getCreatedAt())
+                .paymentOrderStatus(PaymentOrderStatus.CANCELLED.name())
+                .failureMessage(orderRejectedEvent.getOrder().getFailureMessageList())
+                .build();
+    }
 }

--- a/order/src/main/java/com/orderingsystem/order/domain/event/OrderRejectedEvent.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/event/OrderRejectedEvent.java
@@ -1,0 +1,10 @@
+package com.orderingsystem.order.domain.event;
+
+import com.orderingsystem.order.domain.model.Order;
+import java.time.ZonedDateTime;
+
+public class OrderRejectedEvent extends OrderEvent {
+    public OrderRejectedEvent(Order order, ZonedDateTime createdAt) {
+        super(order, createdAt);
+    }
+}

--- a/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
@@ -5,6 +5,7 @@ import com.orderingsystem.common.domain.Money;
 import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.order.domain.event.OrderCancelledEvent;
 import com.orderingsystem.order.domain.event.OrderPaidEvent;
+import com.orderingsystem.order.domain.event.OrderRejectedEvent;
 import com.orderingsystem.order.domain.exception.OrderDomainException;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
@@ -162,6 +163,11 @@ public class Order extends AggregateRoot {
         orderStatus = OrderStatus.APPROVED;
     }
 
+    public OrderRejectedEvent rejecting() {
+        orderStatus = OrderStatus.REJECTING;
+        return new OrderRejectedEvent(this, ZonedDateTime.now());
+    }
+
     public OrderCancelledEvent initCancel(List<String> failureMessages) {
         if (orderStatus != OrderStatus.PAID) {
             throw new OrderDomainException("주문을 취소할 수 없는 상태입니다.");
@@ -189,6 +195,10 @@ public class Order extends AggregateRoot {
         }
         orderStatus = OrderStatus.CANCELLED;
         updateFailureMessages(failureMessages);
+    }
+
+    public void reject() {
+        orderStatus = OrderStatus.REJECTED;
     }
 
     public List<String> getFailureMessageList() {

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
@@ -6,6 +6,7 @@ import com.orderingsystem.common.domain.status.DebeziumOp;
 import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.kafka.KafkaConsumer;
 import com.orderingsystem.order.application.OrderPaymentService;
+import com.orderingsystem.order.application.OrderRestaurantApprovalService;
 import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.infra.kafka.message.PaymentResponseDebeziumMessage;
 import com.orderingsystem.order.infra.kafka.message.PaymentResponseMessage;
@@ -29,6 +30,7 @@ public class PaymentResponseKafkaListener implements KafkaConsumer<String> {
 
     private final ObjectMapper objectMapper;
     private final OrderPaymentService orderPaymentService;
+    private final OrderRestaurantApprovalService orderRestaurantApprovalService;
 
     @Override
     @KafkaListener(id = "${kafka-consumer-config.payment-response-consumer-group-id}",
@@ -66,6 +68,9 @@ public class PaymentResponseKafkaListener implements KafkaConsumer<String> {
                     } else if (PaymentStatus.FAILED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                         log.info("결제 실패. order Id : {}", paymentResponseMessage.getOrderId());
                         orderPaymentService.rollback(paymentResponseMessage.toPaymentResponse(
+                                UUID.fromString(debeziumMessage.getAfter().getId())));
+                    } else if (PaymentStatus.REFUNDED.name().equals(paymentResponseMessage.getPaymentStatus())) {
+                        orderRestaurantApprovalService.reject(paymentResponseMessage.toPaymentResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     }
                 }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/RestaurantOrderDecisionResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/RestaurantOrderDecisionResponseKafkaListener.java
@@ -65,6 +65,12 @@ public class RestaurantOrderDecisionResponseKafkaListener implements KafkaConsum
                         log.info("주문 승인 진행. Order Id : {}", responseMessage.getOrderId());
                         orderRestaurantApprovalService.approve(responseMessage.toDecisionResponse(
                                 UUID.fromString(restaurantResponseDebeziumMessage.getAfter().getId())));
+                    } else if (OrderApprovalStatus.REJECTED.name()
+                            .equals(responseMessage.getOrderApprovalStatus().name())) {
+                        log.info("주문 거절 진행. Order Id : {}", responseMessage.getOrderId());
+                        orderRestaurantApprovalService.rejecting(responseMessage.toDecisionResponse(
+                                UUID.fromString(restaurantResponseDebeziumMessage.getAfter().getId())
+                        ));
                     }
                 }
             } catch (JsonMappingException e) {

--- a/order/src/test/java/com/orderingsystem/order/application/OrderRestaurantApprovalServiceRejectTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderRestaurantApprovalServiceRejectTest.java
@@ -1,0 +1,132 @@
+package com.orderingsystem.order.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.orderingsystem.common.domain.status.OrderStatus;
+import com.orderingsystem.common.saga.SagaStatus;
+import com.orderingsystem.order.application.dto.response.PaymentResponse;
+import com.orderingsystem.order.application.dto.response.RestaurantOrderDecisionResponse;
+import com.orderingsystem.order.application.mapper.OrderDataMapper;
+import com.orderingsystem.order.application.outbox.payment.PaymentOutboxHelper;
+import com.orderingsystem.order.application.outbox.payment.model.OrderPaymentEventPayload;
+import com.orderingsystem.order.domain.event.OrderRejectedEvent;
+import com.orderingsystem.order.domain.model.Order;
+import com.orderingsystem.order.domain.model.outbox.MessageType;
+import com.orderingsystem.order.domain.repository.OrderRepository;
+import com.orderingsystem.order.domain.repository.outbox.ProcessedMessageRepository;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderRestaurantApprovalServiceRejectTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ProcessedMessageRepository processedMessageRepository;
+
+    @Mock
+    private PaymentOutboxHelper paymentOutboxHelper;
+
+    @Mock
+    private OrderDataMapper orderDataMapper;
+
+    @InjectMocks
+    private OrderRestaurantApprovalService orderRestaurantApprovalService;
+
+    @DisplayName("레스토랑이 주문을 거절하면 주문 거절 처리를 시작한다.")
+    @Test
+    void shouldSavePaymentOutboxMessage_whenRestaurantRejectsOrder() {
+        //given
+        UUID messageId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID sagaId = UUID.randomUUID();
+
+        RestaurantOrderDecisionResponse response = mock(RestaurantOrderDecisionResponse.class);
+        given(response.getId()).willReturn(messageId);
+        given(response.getOrderId()).willReturn(orderId);
+        given(response.getSagaId()).willReturn(sagaId);
+
+        given(processedMessageRepository.insertIgnore(eq(messageId), eq(MessageType.RESTAURANT_REJECT.name()), any(
+                ZonedDateTime.class))).willReturn(1);
+
+        Order order = mock(Order.class);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        OrderRejectedEvent orderRejectedEvent = mock(OrderRejectedEvent.class);
+        given(order.rejecting()).willReturn(orderRejectedEvent);
+        given(orderRejectedEvent.getOrder()).willReturn(order);
+
+        given(order.getOrderStatus()).willReturn(OrderStatus.REJECTING);
+
+        OrderPaymentEventPayload paymentEventPayload = mock(OrderPaymentEventPayload.class);
+        given(orderDataMapper.orderRejectedEventToOrderPaymentEventPayload(eq(orderRejectedEvent),
+                eq(sagaId))).willReturn(paymentEventPayload);
+
+        //when
+        orderRestaurantApprovalService.rejecting(response);
+
+        //then
+        verify(paymentOutboxHelper).savePaymentOutboxMessage(eq(paymentEventPayload), eq(OrderStatus.REJECTING), eq(
+                SagaStatus.COMPENSATING), eq(sagaId));
+        verify(order).rejecting();
+    }
+
+    @DisplayName("레스토랑 거절 메시지가 이미 처리되었으면 다시 처리하지 않는다.")
+    @Test
+    void shouldNotProcessRejection_whenMessageAlreadyHandled() {
+        //given
+        UUID messageId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID sagaId = UUID.randomUUID();
+
+        RestaurantOrderDecisionResponse response = mock(RestaurantOrderDecisionResponse.class);
+        given(response.getId()).willReturn(messageId);
+        given(response.getOrderId()).willReturn(orderId);
+        given(response.getSagaId()).willReturn(sagaId);
+
+        given(processedMessageRepository.insertIgnore(eq(messageId), eq(MessageType.RESTAURANT_REJECT.name()),
+                any(ZonedDateTime.class)))
+                .willReturn(0);
+
+        //when
+        orderRestaurantApprovalService.rejecting(response);
+
+        //then
+        verifyNoInteractions(orderRepository, orderDataMapper, paymentOutboxHelper);
+        verify(processedMessageRepository).insertIgnore(eq(messageId), eq(MessageType.RESTAURANT_REJECT.name()),
+                any(ZonedDateTime.class));
+    }
+
+    @DisplayName("주문을 최종 거절 처리한다.")
+    @Test
+    void shouldMarkOrderRejected_whenPaymentDeclined() {
+        //given
+        UUID orderId = UUID.randomUUID();
+        PaymentResponse paymentResponse = mock(PaymentResponse.class);
+        given(paymentResponse.getOrderId()).willReturn(orderId);
+
+        Order order =mock(Order.class);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        //when
+        orderRestaurantApprovalService.reject(paymentResponse);
+
+        //then
+        verify(order).reject();
+    }
+
+}

--- a/payment/src/main/java/com/orderingsystem/payment/application/PaymentService.java
+++ b/payment/src/main/java/com/orderingsystem/payment/application/PaymentService.java
@@ -3,6 +3,7 @@ package com.orderingsystem.payment.application;
 import static com.orderingsystem.common.saga.SagaConstants.ORDER_SAGA_NAME;
 
 import com.orderingsystem.common.domain.Money;
+import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.payment.application.dto.request.PaymentRequest;
 import com.orderingsystem.payment.application.exception.PaymentApplicationException;
@@ -82,7 +83,7 @@ public class PaymentService {
     }
 
     @Transactional
-    public void cancelPayment(PaymentRequest paymentRequest) {
+    public void cancelPayment(PaymentRequest paymentRequest, OrderStatus orderStatus) {
         if (checkAndMarkProcessed(paymentRequest, MessageType.CANCEL_PAYMENT) &&
                 isOutboxMessageProcessedForPayment(paymentRequest, PaymentStatus.CANCELLED)) {
             log.info("해당 Saga Id : {} 에 대한 Outbox 메시지가 이미 취소 상태로 저장되어있어 메시지를 다시 처리하지 않습니다.",
@@ -97,8 +98,17 @@ public class PaymentService {
         List<CreditHistory> creditHistories = getCreditHistories(payment.getCustomerId());
         List<String> failureMessages = new ArrayList<>();
 
-        PaymentEvent paymentEvent = paymentValidateAndCancelService.validateAndCancel(payment, creditEntry,
-                creditHistories, failureMessages);
+        PaymentEvent paymentEvent = null;
+
+        if (orderStatus.equals(OrderStatus.CANCELLING)) {
+            paymentEvent = paymentValidateAndCancelService.validateAndCancel(payment, creditEntry,
+                    creditHistories, failureMessages);
+
+
+        } else if (orderStatus.equals(OrderStatus.REJECTING)) {
+            paymentEvent = paymentValidateAndCancelService.validateAndRefund(payment, creditEntry,
+                    creditHistories, failureMessages);
+        }
 
         if (failureMessages.isEmpty()) {
             creditHistoryRepository.save(creditHistories.get(creditHistories.size() - 1));

--- a/payment/src/main/java/com/orderingsystem/payment/domain/event/PaymentRefundedEvent.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/event/PaymentRefundedEvent.java
@@ -1,0 +1,13 @@
+package com.orderingsystem.payment.domain.event;
+
+import com.orderingsystem.payment.domain.model.Payment;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+public class PaymentRefundedEvent extends PaymentEvent {
+
+    public PaymentRefundedEvent(Payment payment, ZonedDateTime createdAt) {
+        super(payment, createdAt, Collections.emptyList());
+    }
+
+}

--- a/payment/src/main/java/com/orderingsystem/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/model/Payment.java
@@ -6,6 +6,7 @@ import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.payment.domain.event.PaymentCancelledEvent;
 import com.orderingsystem.payment.domain.event.PaymentCompletedEvent;
 import com.orderingsystem.payment.domain.event.PaymentFailedEvent;
+import com.orderingsystem.payment.domain.event.PaymentRefundedEvent;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -88,5 +89,10 @@ public class Payment extends AggregateRoot {
     public PaymentCancelledEvent cancel() {
         this.status = PaymentStatus.CANCELLED;
         return new PaymentCancelledEvent(this, ZonedDateTime.now());
+    }
+
+    public PaymentRefundedEvent refund() {
+        this.status = PaymentStatus.REFUNDED;
+        return new PaymentRefundedEvent(this, ZonedDateTime.now());
     }
 }

--- a/payment/src/main/java/com/orderingsystem/payment/domain/service/PaymentValidateAndCancelService.java
+++ b/payment/src/main/java/com/orderingsystem/payment/domain/service/PaymentValidateAndCancelService.java
@@ -2,6 +2,7 @@ package com.orderingsystem.payment.domain.service;
 
 import com.orderingsystem.payment.domain.event.PaymentCancelledEvent;
 import com.orderingsystem.payment.domain.event.PaymentEvent;
+import com.orderingsystem.payment.domain.event.PaymentRefundedEvent;
 import com.orderingsystem.payment.domain.model.CreditEntry;
 import com.orderingsystem.payment.domain.model.CreditHistory;
 import com.orderingsystem.payment.domain.model.Payment;
@@ -33,6 +34,23 @@ public class PaymentValidateAndCancelService {
         PaymentCancelledEvent paymentCancelledEvent = payment.cancel();
         log.info("결제가 취소되었습니다. Order Id : {}", payment.getOrderId());
         return paymentCancelledEvent;
+    }
+
+    public PaymentEvent validateAndRefund(Payment payment, CreditEntry creditEntry, List<CreditHistory> creditHistories,
+                                          List<String> failureMessages) {
+        payment.validatePayment(failureMessages);
+
+        if (!failureMessages.isEmpty()) {
+            log.error("결제 취소에 실패했습니다. Order Id : {}", payment.getOrderId());
+            return payment.fail(failureMessages);
+        }
+
+        addCreditEntry(payment, creditEntry);
+        updateCreditHistory(payment, creditHistories);
+
+        PaymentRefundedEvent paymentRefundedEvent = payment.refund();
+        log.info("결제가 환불되었습니다. Order Id : {}", payment.getOrderId());
+        return paymentRefundedEvent;
     }
 
     private void addCreditEntry(Payment payment, CreditEntry creditEntry) {

--- a/payment/src/main/java/com/orderingsystem/payment/infra/kafka/listener/PaymentRequestKafkaListener.java
+++ b/payment/src/main/java/com/orderingsystem/payment/infra/kafka/listener/PaymentRequestKafkaListener.java
@@ -3,6 +3,7 @@ package com.orderingsystem.payment.infra.kafka.listener;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.DebeziumOp;
+import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.domain.status.PaymentOrderStatus;
 import com.orderingsystem.kafka.KafkaSingleConsumer;
 import com.orderingsystem.payment.application.PaymentService;
@@ -36,7 +37,8 @@ public class PaymentRequestKafkaListener implements KafkaSingleConsumer<String> 
                         @Header(KafkaHeaders.OFFSET) Long offset) {
 
         try {
-            PaymentRequestDebeziumMessage debeziumMessage = objectMapper.readValue(message, PaymentRequestDebeziumMessage.class);
+            PaymentRequestDebeziumMessage debeziumMessage = objectMapper.readValue(message,
+                    PaymentRequestDebeziumMessage.class);
 
             if (debeziumMessage.getBefore() == null && debeziumMessage.getOp().equals(DebeziumOp.CREATE.getValue())) {
                 log.info("PaymentRequestKafkaListener에서 메시지를 받았습니다. message : {}, key : {}, partition : {}, offset: {}",
@@ -51,7 +53,8 @@ public class PaymentRequestKafkaListener implements KafkaSingleConsumer<String> 
                     paymentService.completePayment(requestMessage.toPaymentRequest());
                 } else if (PaymentOrderStatus.CANCELLED.equals(requestMessage.getPaymentOrderStatus())) {
                     log.info("결제 취소 진행. order Id : {}", requestMessage.getOrderId());
-                    paymentService.cancelPayment(requestMessage.toPaymentRequest());
+                    paymentService.cancelPayment(requestMessage.toPaymentRequest(),
+                            OrderStatus.valueOf(debeziumMessage.getAfter().getOrderStatus()));
                 }
             }
 

--- a/payment/src/test/java/com/orderingsystem/payment/application/PaymentServiceCancelTest.java
+++ b/payment/src/test/java/com/orderingsystem/payment/application/PaymentServiceCancelTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.Money;
+import com.orderingsystem.common.domain.status.OrderStatus;
 import com.orderingsystem.common.domain.status.PaymentOrderStatus;
 import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.payment.application.dto.request.PaymentRequest;
@@ -117,7 +118,7 @@ class PaymentServiceCancelTest {
         Optional<Payment> beforePayment = paymentRepository.findByOrderId(orderId);
         assertThat(beforePayment.get().getStatus()).isEqualTo(PaymentStatus.COMPLETED);
 
-        paymentService.cancelPayment(paymentRequest);
+        paymentService.cancelPayment(paymentRequest, OrderStatus.CANCELLING);
 
         //then
         Optional<Payment> payment = paymentRepository.findByOrderId(orderId);
@@ -151,7 +152,7 @@ class PaymentServiceCancelTest {
                 .build());
 
         //when
-        paymentService.cancelPayment(paymentRequest);
+        paymentService.cancelPayment(paymentRequest, OrderStatus.CANCELLING);
 
         //then
         Optional<Payment> payment = paymentRepository.findByOrderId(orderId);
@@ -197,7 +198,7 @@ class PaymentServiceCancelTest {
                 .build());
 
         //when
-        paymentService.cancelPayment(paymentRequest);
+        paymentService.cancelPayment(paymentRequest, OrderStatus.CANCELLING);
 
         //then
         Optional<Payment> payment = paymentRepository.findByOrderId(orderId);
@@ -234,7 +235,7 @@ class PaymentServiceCancelTest {
                 .build());
 
         //when
-        paymentService.cancelPayment(paymentRequest);
+        paymentService.cancelPayment(paymentRequest, OrderStatus.CANCELLING);
 
         //then
         Optional<Payment> payment = paymentRepository.findByOrderId(orderId);
@@ -259,9 +260,67 @@ class PaymentServiceCancelTest {
                 .build();
 
         //when, then
-        assertThatThrownBy(() -> paymentService.cancelPayment(paymentRequest))
+        assertThatThrownBy(() -> paymentService.cancelPayment(paymentRequest,
+                OrderStatus.CANCELLING))
                 .isInstanceOf(PaymentApplicationException.class)
                 .hasMessage("해당 주문에 대한 결제 정보를 찾지 못했습니다. Order Id : " + orderId);
+    }
+
+    @DisplayName("주문 상태가 REJECTING이면 validateAndRefund가 호출되고, 상태는 CANCELLED가 된다.")
+    @Test
+    void shouldRefundPayment_whenOrderStatusIsRejecting() {
+        //given
+        PaymentRequest paymentRequest = PaymentRequest.builder()
+                .id(UUID.randomUUID())
+                .sagaId(sagaId)
+                .orderId(orderId)
+                .customerId(customerId)
+                .price(new BigDecimal("25.00"))
+                .createdAt(Instant.now())
+                .paymentOrderStatus(PaymentOrderStatus.PENDING)
+                .build();
+
+        //when
+        paymentService.cancelPayment(paymentRequest, OrderStatus.REJECTING);
+
+        //then
+        Optional<Payment> payment = paymentRepository.findByOrderId(orderId);
+        assertThat(payment).isPresent();
+        assertThat(payment.get().getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+    }
+
+    @DisplayName("실패 메시지가 존재할 경우 CreditHistory는 저장되지 않는다.")
+    @Test
+    void shouldNotSaveCreditHistory_whenFailureMessagesExist() {
+        // given
+        UUID negativeOrderId = UUID.randomUUID();
+
+        paymentRepository.save(Payment.builder()
+                .id(UUID.randomUUID())
+                .customerId(customerId)
+                .orderId(negativeOrderId)
+                .price(new Money(new BigDecimal("-25.00")))
+                .status(PaymentStatus.COMPLETED)
+                .build());
+
+        PaymentRequest paymentRequest = PaymentRequest.builder()
+                .id(UUID.randomUUID())
+                .sagaId(sagaId)
+                .orderId(negativeOrderId)
+                .customerId(customerId)
+                .price(new BigDecimal("-25.00"))
+                .createdAt(Instant.now())
+                .paymentOrderStatus(PaymentOrderStatus.CANCELLED)
+                .build();
+
+        long beforeCount = creditHistoryRepository.count();
+
+        // when
+        paymentService.cancelPayment(paymentRequest, OrderStatus.CANCELLING);
+
+        // then
+        long afterCount = creditHistoryRepository.count();
+        assertThat(afterCount).isEqualTo(beforeCount);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #47 

## 📝작업 내용

> 기존 레스토랑 주문 거절 후 order, payment 처리 진행하지 않았던 문제 수정

- PaymentStatus `REFUNDED` 추가
- OrderStatus `REJECTED, REJECTING` 추가

- restaurant 서비스에서 거절 -> order 서비스 `REJECTING` 처리 -> payment 환불 진행(`REFUNDED`) -> order 서비스 최종 `REJECTED` 처리
