### PR TITLE
[Feature] #51 쿠폰

### DIFF
--- a/common/src/main/java/com/orderingsystem/common/config/SchedulerProperties.java
+++ b/common/src/main/java/com/orderingsystem/common/config/SchedulerProperties.java
@@ -1,0 +1,15 @@
+package com.orderingsystem.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "scheduler")
+public class SchedulerProperties {
+
+    private int poolSize = 5;
+    private String threadNamePrefix = "CommonScheduler-";
+
+}

--- a/common/src/main/java/com/orderingsystem/common/config/SchedulingConfig.java
+++ b/common/src/main/java/com/orderingsystem/common/config/SchedulingConfig.java
@@ -1,0 +1,30 @@
+package com.orderingsystem.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SchedulerProperties.class)
+public class SchedulingConfig {
+
+    private final SchedulerProperties schedulerProperties;
+
+    @Bean
+    public TaskScheduler taskScheduler(){
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+        scheduler.setPoolSize(schedulerProperties.getPoolSize());
+        scheduler.setThreadNamePrefix(schedulerProperties.getThreadNamePrefix());
+
+        scheduler.initialize();
+        return scheduler;
+    }
+
+}

--- a/common/src/main/java/com/orderingsystem/common/domain/status/UserType.java
+++ b/common/src/main/java/com/orderingsystem/common/domain/status/UserType.java
@@ -1,4 +1,4 @@
-package com.orderingsystem.domain.model;
+package com.orderingsystem.common.domain.status;
 
 public enum UserType {
     CUSTOMER, ADMIN, RESTAURANT_OWNER

--- a/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/orderingsystem/common/exception/GlobalExceptionHandler.java
@@ -49,6 +49,17 @@ public class GlobalExceptionHandler {
                         .build());
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorDTO> handleIllegalStateException(IllegalStateException e) {
+        log.error(e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .message(e.getMessage())
+                        .build());
+    }
+
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorDTO> handleNotFoundException(NotFoundException e) {
         log.error(e.getMessage());

--- a/common/src/main/java/com/orderingsystem/common/util/CommonJwtUtil.java
+++ b/common/src/main/java/com/orderingsystem/common/util/CommonJwtUtil.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.common.util;
 
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.common.exception.InvalidCredentialsException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -63,6 +64,32 @@ public class CommonJwtUtil {
 
         Claims claims = getClaims(accessToken);
         return UUID.fromString(claims.get("userId", String.class));
+    }
+
+    public UserType getUserRoleFromToken(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")){
+            throw new InvalidCredentialsException("Authorization 헤더가 유효하지 않습니다.");
+        }
+
+        String accessToken = authorizationHeader.replace("Bearer ", "").trim();
+
+        if (!isValidAccessToken(accessToken)) {
+            throw new InvalidCredentialsException("AccessToken 검증에 실패했습니다.");
+        }
+
+        Claims claims = getClaims(accessToken);
+
+        Object raw = claims.get("role");
+        if (raw instanceof String s) {
+            return UserType.valueOf(s.toUpperCase());
+        }
+
+        var list = claims.get("roles", java.util.List.class);
+        if (list != null && !list.isEmpty()) {
+            Object first = list.get(0);
+            if (first instanceof String fs) return UserType.valueOf(fs.toUpperCase());
+        }
+        throw new InvalidCredentialsException("role 클레임이 없거나 형식이 잘못되었습니다.");
     }
 
     private boolean isValidAccessToken(String token) {

--- a/coupon/.gitignore
+++ b/coupon/.gitignore
@@ -1,0 +1,52 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### ds_store ###
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store
+
+### env value ###
+.env
+
+application.yml
+src/main/resources/application.yml
+src/main/resources/*.yml
+application-test.yml
+

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -19,8 +19,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.kafka:spring-kafka'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.6'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.assertj:assertj-core:3.25.3'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation project(':common')
     implementation project(':infrastructure')

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.food.ordering.system'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+
+    implementation project(':common')
+    implementation project(':infrastructure')
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+

--- a/coupon/src/main/java/com/orderingsystem/CouponApplication.java
+++ b/coupon/src/main/java/com/orderingsystem/CouponApplication.java
@@ -2,8 +2,10 @@ package com.orderingsystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CouponApplication {
 
     public static void main(String[] args) {

--- a/coupon/src/main/java/com/orderingsystem/CouponApplication.java
+++ b/coupon/src/main/java/com/orderingsystem/CouponApplication.java
@@ -1,0 +1,13 @@
+package com.orderingsystem;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CouponApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CouponApplication.class, args);
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -15,13 +15,13 @@ public class CouponFacade {
 
     private final CreateCouponService createCouponService;
 
-    public void createCoupon(CreateCouponApplicationRequest request, UserType userType, UUID userId) {
+    public UUID createCoupon(CreateCouponApplicationRequest request, UserType userType, UUID userId) {
         if (!UserType.ADMIN.equals(userType)) {
             log.info("관리자가 아닌 유저가 쿠폰 생성 시도. UserId : [{}], UserType : [{}]", userId, userType);
             throw new AccessDeniedException("쿠폰 생성이 불가능합니다.");
         }
 
-        createCouponService.create(request, userId);
+        return createCouponService.create(request, userId);
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -1,0 +1,27 @@
+package com.orderingsystem.coupon.application;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.common.exception.AccessDeniedException;
+import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CouponFacade {
+
+    private final CreateCouponService createCouponService;
+
+    public void createCoupon(CreateCouponApplicationRequest request, UserType userType, UUID userId) {
+        if (!UserType.ADMIN.equals(userType)) {
+            log.info("관리자가 아닌 유저가 쿠폰 생성 시도. UserId : [{}], UserType : [{}]", userId, userType);
+            throw new AccessDeniedException("쿠폰 생성이 불가능합니다.");
+        }
+
+        createCouponService.create(request, userId);
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -3,6 +3,7 @@ package com.orderingsystem.coupon.application;
 import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.common.exception.AccessDeniedException;
 import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ public class CouponFacade {
 
     private final CreateCouponService createCouponService;
     private final CouponManagementService couponManagementService;
+    private final CouponCachePort couponCachePort;
 
     public UUID createCoupon(CreateCouponApplicationRequest request, UserType userType, UUID userId) {
         if (!UserType.ADMIN.equals(userType)) {
@@ -32,5 +34,7 @@ public class CouponFacade {
         }
 
         couponManagementService.pause(couponId, userId);
+        couponCachePort.deleteCouponStock(couponId);
     }
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -34,7 +34,14 @@ public class CouponFacade {
         }
 
         couponManagementService.pause(couponId, userId);
-        couponCachePort.deleteCouponStock(couponId);
     }
 
+    public void resumeCoupon(UUID couponId, UUID userId, UserType userType) {
+        if (!UserType.ADMIN.equals(userType)) {
+            log.info("관리자가 아닌 유저가 쿠폰 재시작 시도. UserId : [{}], UserType : [{}]", userId, userType);
+            throw new AccessDeniedException("쿠폰 재시작이 불가능합니다.");
+        }
+
+        couponManagementService.resume(couponId, userId);
+    }
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -44,4 +44,13 @@ public class CouponFacade {
 
         couponManagementService.resume(couponId, userId);
     }
+
+    public void terminateCoupon(UUID couponId, UUID userId, UserType userType) {
+        if (!UserType.ADMIN.equals(userType)) {
+            log.info("관리자가 아닌 유저가 쿠폰 종료 시도. UserId : [{}], UserType : [{}]", userId, userType);
+            throw new AccessDeniedException("쿠폰 종료가 불가능합니다.");
+        }
+
+        couponManagementService.terminate(couponId, userId);
+    }
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponFacade.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class CouponFacade {
 
     private final CreateCouponService createCouponService;
+    private final CouponManagementService couponManagementService;
 
     public UUID createCoupon(CreateCouponApplicationRequest request, UserType userType, UUID userId) {
         if (!UserType.ADMIN.equals(userType)) {
@@ -24,4 +25,12 @@ public class CouponFacade {
         return createCouponService.create(request, userId);
     }
 
+    public void pauseCoupon(UUID couponId, UUID userId, UserType userType) {
+        if (!UserType.ADMIN.equals(userType)) {
+            log.info("관리자가 아닌 유저가 쿠폰 정지 시도. UserId : [{}], UserType : [{}]", userId, userType);
+            throw new AccessDeniedException("쿠폰 정지가 불가능합니다.");
+        }
+
+        couponManagementService.pause(couponId, userId);
+    }
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.coupon.application;
 
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponManagementService {
 
     private final CouponRepository couponRepository;
+    private final CouponCachePort couponCachePort;
 
     @Transactional
     public void pause(UUID couponId, UUID userId) {
@@ -23,6 +25,19 @@ public class CouponManagementService {
 
         Coupon coupon = getCoupon(couponId, userId);
         coupon.pause();
+
+        couponCachePort.deleteCouponStock(couponId);
+    }
+
+    @Transactional
+    public void resume(UUID couponId, UUID userId) {
+        log.info("[{}] 유저가 [{}] 쿠폰 재시작.", userId, couponId);
+
+        Coupon coupon = getCoupon(couponId, userId);
+        coupon.resume();
+
+        couponCachePort.enableCoupon(couponId, coupon.getIssueLimit() - coupon.getIssuedCount(),
+                coupon.getValidUntil());
     }
 
     private Coupon getCoupon(UUID couponId, UUID userId) {

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
@@ -40,14 +40,24 @@ public class CouponManagementService {
                 coupon.getValidUntil());
     }
 
+    @Transactional
+    public void terminate(UUID couponId, UUID userId) {
+        log.info("[{}] 유저가 [{}] 쿠폰 종료.", userId, couponId);
+
+        Coupon coupon = getCoupon(couponId, userId);
+        coupon.terminate();
+
+        couponCachePort.deleteCouponStock(couponId);
+        couponCachePort.setExpireIssuedUserKey(couponId);
+    }
+
     private Coupon getCoupon(UUID couponId, UUID userId) {
         Optional<Coupon> coupon = couponRepository.findById(couponId);
-        if (coupon.isEmpty()){
+        if (coupon.isEmpty()) {
             log.info("[{}] 쿠폰이 존재하지 않습니다. 조회한 유저 : [{}]", coupon, userId);
             throw new CouponNotFoundException("쿠폰이 존재하지 않습니다.");
         }
 
         return coupon.get();
     }
-
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CouponManagementService.java
@@ -1,0 +1,38 @@
+package com.orderingsystem.coupon.application;
+
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CouponManagementService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void pause(UUID couponId, UUID userId) {
+        log.info("[{}] 유저가 [{}] 쿠폰 정지.", userId, couponId);
+
+        Coupon coupon = getCoupon(couponId, userId);
+        coupon.pause();
+    }
+
+    private Coupon getCoupon(UUID couponId, UUID userId) {
+        Optional<Coupon> coupon = couponRepository.findById(couponId);
+        if (coupon.isEmpty()){
+            log.info("[{}] 쿠폰이 존재하지 않습니다. 조회한 유저 : [{}]", coupon, userId);
+            throw new CouponNotFoundException("쿠폰이 존재하지 않습니다.");
+        }
+
+        return coupon.get();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
@@ -17,7 +17,7 @@ public class CreateCouponService {
     private final CouponRepository couponRepository;
 
     @Transactional
-    public void create(CreateCouponApplicationRequest request, UUID userId) {
+    public UUID create(CreateCouponApplicationRequest request, UUID userId) {
         log.info("[{}] 유저가 쿠폰 생성 요청. 쿠폰 정보 : [{}]", userId, request.toString());
 
         Coupon coupon = Coupon.create(request.getDiscountType(), request.getAmountOff(), request.getPercentOff(),
@@ -25,6 +25,8 @@ public class CreateCouponService {
                 request.getValidUntil(), request.getIssueLimit());
 
         couponRepository.save(coupon);
+
+        return coupon.getCouponId();
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
@@ -1,0 +1,30 @@
+package com.orderingsystem.coupon.application;
+
+import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CreateCouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void create(CreateCouponApplicationRequest request, UUID userId) {
+        log.info("[{}] 유저가 쿠폰 생성 요청. 쿠폰 정보 : [{}]", userId, request.toString());
+
+        Coupon coupon = Coupon.create(request.getDiscountType(), request.getAmountOff(), request.getPercentOff(),
+                request.getMaxDiscountAmount(), request.getMinDiscountAmount(), request.getValidFrom(),
+                request.getValidUntil(), request.getIssueLimit());
+
+        couponRepository.save(coupon);
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
@@ -22,7 +22,7 @@ public class CreateCouponService {
 
         Coupon coupon = Coupon.create(request.getDiscountType(), request.getAmountOff(), request.getPercentOff(),
                 request.getMaxDiscountAmount(), request.getMinDiscountAmount(), request.getValidFrom(),
-                request.getValidUntil(), request.getIssueLimit());
+                request.getValidUntil(), request.getIssueLimit(), request.getName());
 
         couponRepository.save(coupon);
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
@@ -22,7 +22,7 @@ public class CreateCouponService {
 
         Coupon coupon = Coupon.create(request.getDiscountType(), request.getAmountOff(), request.getPercentOff(),
                 request.getMaxDiscountAmount(), request.getMinDiscountAmount(), request.getValidFrom(),
-                request.getValidUntil(), request.getIssueLimit(), request.getName());
+                request.getValidUntil(), request.getIssueLimit(), request.getName(), request.getValidDays());
 
         couponRepository.save(coupon);
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/CreateCouponService.java
@@ -1,6 +1,7 @@
 package com.orderingsystem.coupon.application;
 
 import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponSchedulerPort;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import java.util.UUID;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateCouponService {
 
     private final CouponRepository couponRepository;
+    private final CouponSchedulerPort couponSchedulerPort;
 
     @Transactional
     public UUID create(CreateCouponApplicationRequest request, UUID userId) {
@@ -24,7 +26,11 @@ public class CreateCouponService {
                 request.getMaxDiscountAmount(), request.getMinDiscountAmount(), request.getValidFrom(),
                 request.getValidUntil(), request.getIssueLimit(), request.getName(), request.getValidDays());
 
-        couponRepository.save(coupon);
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        couponSchedulerPort.scheduleCouponStart(
+                savedCoupon.getCouponId(), savedCoupon.getIssueLimit(),
+                savedCoupon.getValidFrom(), savedCoupon.getValidUntil());
 
         return coupon.getCouponId();
     }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -1,7 +1,9 @@
 package com.orderingsystem.coupon.application;
 
+import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
 import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
@@ -11,17 +13,19 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FindCouponService {
 
     private final CouponRepository couponRepository;
     private final IssuedCouponRepository issuedCouponRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<IssuedCouponResponse> getIssuedCoupons(UUID userId, List<IssuedCouponStatus> couponStatus) {
         List<IssuedCoupon> issuedCoupons = issuedCouponRepository.findByUserIdAndStatusIn(userId, couponStatus);
 
@@ -34,6 +38,11 @@ public class FindCouponService {
         Map<UUID, Coupon> couponMap = coupons.stream()
                 .collect(Collectors.toMap(Coupon::getCouponId, coupon -> coupon));
 
+        return buildIssueCouponResponse(issuedCoupons, couponMap);
+    }
+
+    private List<IssuedCouponResponse> buildIssueCouponResponse(List<IssuedCoupon> issuedCoupons,
+                                                                Map<UUID, Coupon> couponMap) {
         return issuedCoupons.stream()
                 .map(issuedCoupon -> {
                     Coupon coupon = couponMap.get(issuedCoupon.getCouponId());
@@ -53,6 +62,35 @@ public class FindCouponService {
                             .minOrderAmount(coupon.getMinDiscountAmount())
                             .build();
                 }).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CouponResponse> getCoupons(UUID userId, List<CouponStatus> couponStatuses) {
+        log.info("[{}] 유저가 쿠폰 조회.", userId);
+
+        List<Coupon> coupons = couponRepository.findAllByStatusIn(couponStatuses);
+
+        return buildCouponResponse(coupons);
+    }
+
+    private List<CouponResponse> buildCouponResponse(List<Coupon> coupons) {
+        return coupons.stream().map(coupon -> {
+            return CouponResponse.builder()
+                    .couponId(coupon.getCouponId())
+                    .couponName(coupon.getName())
+                    .discountType(coupon.getDiscountType())
+                    .couponStatus(coupon.getStatus())
+                    .amountOff(coupon.getAmountOff())
+                    .percentOff(coupon.getPercentOff())
+                    .maxDiscountAmount(coupon.getMaxDiscountAmount())
+                    .minDiscountAmount(coupon.getMinDiscountAmount())
+                    .validFrom(coupon.getValidFrom())
+                    .validUntil(coupon.getValidUntil())
+                    .validDays(coupon.getValidDays())
+                    .issueLimit(coupon.getIssueLimit())
+                    .issuedCount(coupon.getIssuedCount())
+                    .build();
+        }).toList();
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -1,0 +1,58 @@
+package com.orderingsystem.coupon.application;
+
+import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FindCouponService {
+
+    private final CouponRepository couponRepository;
+    private final IssuedCouponRepository issuedCouponRepository;
+
+    @Transactional
+    public List<IssuedCouponResponse> getIssuedCoupons(UUID userId, List<IssuedCouponStatus> couponStatus) {
+        List<IssuedCoupon> issuedCoupons = issuedCouponRepository.findByUserIdAndStatusIn(userId, couponStatus);
+
+        List<UUID> couponIds = issuedCoupons.stream()
+                .map(IssuedCoupon::getCouponId)
+                .toList();
+
+        List<Coupon> coupons = couponRepository.findAllByCouponIdIn(couponIds);
+
+        Map<UUID, Coupon> couponMap = coupons.stream()
+                .collect(Collectors.toMap(Coupon::getCouponId, coupon -> coupon));
+
+        return issuedCoupons.stream()
+                .map(issuedCoupon -> {
+                    Coupon coupon = couponMap.get(issuedCoupon.getCouponId());
+
+                    return IssuedCouponResponse.builder()
+                            .couponId(issuedCoupon.getCouponId())
+                            .couponName(coupon.getName())
+                            .issuedCouponId(issuedCoupon.getId())
+                            .issuedCouponStatus(issuedCoupon.getStatus())
+                            .issuedAt(issuedCoupon.getIssuedAt())
+                            .usedAt(issuedCoupon.getUsedAt())
+                            .expiredAt(issuedCoupon.getExpiredAt())
+                            .discountType(coupon.getDiscountType())
+                            .amountOff(coupon.getAmountOff())
+                            .percentOff(coupon.getPercentOff())
+                            .maxDiscountAmount(coupon.getMaxDiscountAmount())
+                            .minOrderAmount(coupon.getMinDiscountAmount())
+                            .build();
+                }).toList();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.coupon.application;
 
+import com.orderingsystem.common.exception.AccessDeniedException;
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
@@ -40,29 +41,11 @@ public class FindCouponService {
         Map<UUID, Coupon> couponMap = coupons.stream()
                 .collect(Collectors.toMap(Coupon::getCouponId, coupon -> coupon));
 
-        return buildIssueCouponResponse(issuedCoupons, couponMap);
-    }
-
-    private List<IssuedCouponResponse> buildIssueCouponResponse(List<IssuedCoupon> issuedCoupons,
-                                                                Map<UUID, Coupon> couponMap) {
         return issuedCoupons.stream()
                 .map(issuedCoupon -> {
                     Coupon coupon = couponMap.get(issuedCoupon.getCouponId());
 
-                    return IssuedCouponResponse.builder()
-                            .couponId(issuedCoupon.getCouponId())
-                            .couponName(coupon.getName())
-                            .issuedCouponId(issuedCoupon.getId())
-                            .issuedCouponStatus(issuedCoupon.getStatus())
-                            .issuedAt(issuedCoupon.getIssuedAt())
-                            .usedAt(issuedCoupon.getUsedAt())
-                            .expiredAt(issuedCoupon.getExpiredAt())
-                            .discountType(coupon.getDiscountType())
-                            .amountOff(coupon.getAmountOff())
-                            .percentOff(coupon.getPercentOff())
-                            .maxDiscountAmount(coupon.getMaxDiscountAmount())
-                            .minOrderAmount(coupon.getMinDiscountAmount())
-                            .build();
+                    return buildIssueCouponResponse(issuedCoupon, coupon);
                 }).toList();
     }
 
@@ -79,6 +62,33 @@ public class FindCouponService {
     public CouponResponse getCoupon(UUID userId, UUID couponId) {
         Coupon coupon = findCoupon(userId, couponId);
         return buildCouponResponse(coupon);
+    }
+
+    @Transactional(readOnly = true)
+    public IssuedCouponResponse getIssuedCoupon(UUID userId, Long issuedCouponId) {
+        IssuedCoupon issuedCoupon = findIssuedCoupon(userId, issuedCouponId);
+        ensureUserOwnsIssuedCoupon(userId, issuedCoupon);
+
+        Coupon coupon = findCoupon(userId, issuedCoupon.getCouponId());
+
+        return buildIssueCouponResponse(issuedCoupon, coupon);
+    }
+
+    private IssuedCoupon findIssuedCoupon(UUID userId, Long issuedCouponId) {
+        Optional<IssuedCoupon> issuedCoupon = issuedCouponRepository.findById(issuedCouponId);
+        if (issuedCoupon.isEmpty()) {
+            log.info("[{}] 유저가 발급한 쿠폰 정보가 존재하지 않는 쿠폰 발급 요청. issuedCouponId : [{}]", userId, issuedCouponId);
+            throw new CouponNotFoundException("발급한 쿠폰 정보가 존재하지 않습니다.");
+        }
+
+        return issuedCoupon.get();
+    }
+
+    private void ensureUserOwnsIssuedCoupon(UUID userId, IssuedCoupon issuedCoupon) {
+        if (!issuedCoupon.getUserId().equals(userId)) {
+            log.info("[{}] 유저가 본인이 발급하지 않은 발급 쿠폰 정보 조회 요청. issuedCouponId : [{}]", userId, issuedCoupon.getId());
+            throw new AccessDeniedException("발급한 쿠폰 정보를 조회할 권한이 없습니다.");
+        }
     }
 
     private Coupon findCoupon(UUID userId, UUID couponId) {
@@ -106,6 +116,23 @@ public class FindCouponService {
                 .validDays(coupon.getValidDays())
                 .issueLimit(coupon.getIssueLimit())
                 .issuedCount(coupon.getIssuedCount())
+                .build();
+    }
+
+    private IssuedCouponResponse buildIssueCouponResponse(IssuedCoupon issuedCoupon, Coupon coupon) {
+        return IssuedCouponResponse.builder()
+                .couponId(issuedCoupon.getCouponId())
+                .couponName(coupon.getName())
+                .issuedCouponId(issuedCoupon.getId())
+                .issuedCouponStatus(issuedCoupon.getStatus())
+                .issuedAt(issuedCoupon.getIssuedAt())
+                .usedAt(issuedCoupon.getUsedAt())
+                .expiredAt(issuedCoupon.getExpiredAt())
+                .discountType(coupon.getDiscountType())
+                .amountOff(coupon.getAmountOff())
+                .percentOff(coupon.getPercentOff())
+                .maxDiscountAmount(coupon.getMaxDiscountAmount())
+                .minOrderAmount(coupon.getMinDiscountAmount())
                 .build();
     }
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -2,6 +2,7 @@ package com.orderingsystem.coupon.application;
 
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
@@ -10,6 +11,7 @@ import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -70,27 +72,41 @@ public class FindCouponService {
 
         List<Coupon> coupons = couponRepository.findAllByStatusIn(couponStatuses);
 
-        return buildCouponResponse(coupons);
+        return coupons.stream().map(this::buildCouponResponse).toList();
     }
 
-    private List<CouponResponse> buildCouponResponse(List<Coupon> coupons) {
-        return coupons.stream().map(coupon -> {
-            return CouponResponse.builder()
-                    .couponId(coupon.getCouponId())
-                    .couponName(coupon.getName())
-                    .discountType(coupon.getDiscountType())
-                    .couponStatus(coupon.getStatus())
-                    .amountOff(coupon.getAmountOff())
-                    .percentOff(coupon.getPercentOff())
-                    .maxDiscountAmount(coupon.getMaxDiscountAmount())
-                    .minDiscountAmount(coupon.getMinDiscountAmount())
-                    .validFrom(coupon.getValidFrom())
-                    .validUntil(coupon.getValidUntil())
-                    .validDays(coupon.getValidDays())
-                    .issueLimit(coupon.getIssueLimit())
-                    .issuedCount(coupon.getIssuedCount())
-                    .build();
-        }).toList();
+    @Transactional(readOnly = true)
+    public CouponResponse getCoupon(UUID userId, UUID couponId) {
+        Coupon coupon = findCoupon(userId, couponId);
+        return buildCouponResponse(coupon);
+    }
+
+    private Coupon findCoupon(UUID userId, UUID couponId) {
+        Optional<Coupon> coupon = couponRepository.findById(couponId);
+        if (coupon.isEmpty()) {
+            log.info("[{}] 유저가 존재하지 않는 쿠폰 [{}] 조회 요청.", userId, couponId);
+            throw new CouponNotFoundException("쿠폰이 존재하지 않습니다.");
+        }
+
+        return coupon.get();
+    }
+
+    private CouponResponse buildCouponResponse(Coupon coupon) {
+        return CouponResponse.builder()
+                .couponId(coupon.getCouponId())
+                .couponName(coupon.getName())
+                .discountType(coupon.getDiscountType())
+                .couponStatus(coupon.getStatus())
+                .amountOff(coupon.getAmountOff())
+                .percentOff(coupon.getPercentOff())
+                .maxDiscountAmount(coupon.getMaxDiscountAmount())
+                .minDiscountAmount(coupon.getMinDiscountAmount())
+                .validFrom(coupon.getValidFrom())
+                .validUntil(coupon.getValidUntil())
+                .validDays(coupon.getValidDays())
+                .issueLimit(coupon.getIssueLimit())
+                .issuedCount(coupon.getIssuedCount())
+                .build();
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -10,9 +10,11 @@ import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -53,9 +55,17 @@ public class FindCouponService {
     public List<CouponResponse> getCoupons(UUID userId, List<CouponStatus> couponStatuses) {
         log.info("[{}] 유저가 쿠폰 조회.", userId);
 
-        List<Coupon> coupons = couponRepository.findAllByStatusIn(couponStatuses);
+        Set<CouponStatus> searchStatuses = new HashSet<>(couponStatuses);
+        if (couponStatuses.contains(CouponStatus.EXPIRED)) {
+            searchStatuses.add(CouponStatus.ACTIVE);
+        }
 
-        return coupons.stream().map(this::buildCouponResponse).toList();
+        List<Coupon> coupons = couponRepository.findAllByStatusIn(searchStatuses);
+
+        return coupons.stream()
+                .map(this::buildCouponResponse)
+                .filter(res -> couponStatuses.contains(res.getCouponStatus()))
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -106,7 +116,7 @@ public class FindCouponService {
                 .couponId(coupon.getCouponId())
                 .couponName(coupon.getName())
                 .discountType(coupon.getDiscountType())
-                .couponStatus(coupon.getStatus())
+                .couponStatus(coupon.getDisplayStatus())
                 .amountOff(coupon.getAmountOff())
                 .percentOff(coupon.getPercentOff())
                 .maxDiscountAmount(coupon.getMaxDiscountAmount())

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/FindCouponService.java
@@ -31,27 +31,6 @@ public class FindCouponService {
     private final IssuedCouponRepository issuedCouponRepository;
 
     @Transactional(readOnly = true)
-    public List<IssuedCouponResponse> getIssuedCoupons(UUID userId, List<IssuedCouponStatus> couponStatus) {
-        List<IssuedCoupon> issuedCoupons = issuedCouponRepository.findByUserIdAndStatusIn(userId, couponStatus);
-
-        List<UUID> couponIds = issuedCoupons.stream()
-                .map(IssuedCoupon::getCouponId)
-                .toList();
-
-        List<Coupon> coupons = couponRepository.findAllByCouponIdIn(couponIds);
-
-        Map<UUID, Coupon> couponMap = coupons.stream()
-                .collect(Collectors.toMap(Coupon::getCouponId, coupon -> coupon));
-
-        return issuedCoupons.stream()
-                .map(issuedCoupon -> {
-                    Coupon coupon = couponMap.get(issuedCoupon.getCouponId());
-
-                    return buildIssueCouponResponse(issuedCoupon, coupon);
-                }).toList();
-    }
-
-    @Transactional(readOnly = true)
     public List<CouponResponse> getCoupons(UUID userId, List<CouponStatus> couponStatuses) {
         log.info("[{}] 유저가 쿠폰 조회.", userId);
 
@@ -72,6 +51,39 @@ public class FindCouponService {
     public CouponResponse getCoupon(UUID userId, UUID couponId) {
         Coupon coupon = findCoupon(userId, couponId);
         return buildCouponResponse(coupon);
+    }
+
+    @Transactional(readOnly = true)
+    public List<IssuedCouponResponse> getIssuedCoupons(UUID userId, List<IssuedCouponStatus> couponStatuses) {
+        log.info("[{}] 유저가 발급된 쿠폰 조회.", userId);
+
+        Set<IssuedCouponStatus> searchStatuses = new HashSet<>(couponStatuses);
+        if (couponStatuses.contains(IssuedCouponStatus.EXPIRED)) {
+            searchStatuses.add(IssuedCouponStatus.ISSUED);
+        }
+
+        List<IssuedCoupon> issuedCoupons = issuedCouponRepository.findByUserIdAndStatusIn(userId, searchStatuses);
+
+        if (issuedCoupons.isEmpty()) {
+            return List.of();
+        }
+
+        List<UUID> couponIds = issuedCoupons.stream()
+                .map(IssuedCoupon::getCouponId)
+                .toList();
+
+        List<Coupon> coupons = couponRepository.findAllByCouponIdIn(couponIds);
+
+        Map<UUID, Coupon> couponMap = coupons.stream()
+                .collect(Collectors.toMap(Coupon::getCouponId, coupon -> coupon));
+
+        return issuedCoupons.stream()
+                .map(issuedCoupon -> {
+                    Coupon coupon = couponMap.get(issuedCoupon.getCouponId());
+                    return buildIssueCouponResponse(issuedCoupon, coupon);
+                })
+                .filter(res -> couponStatuses.contains(res.getIssuedCouponStatus()))
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -134,7 +146,7 @@ public class FindCouponService {
                 .couponId(issuedCoupon.getCouponId())
                 .couponName(coupon.getName())
                 .issuedCouponId(issuedCoupon.getId())
-                .issuedCouponStatus(issuedCoupon.getStatus())
+                .issuedCouponStatus(issuedCoupon.getDisplayStatus())
                 .issuedAt(issuedCoupon.getIssuedAt())
                 .usedAt(issuedCoupon.getUsedAt())
                 .expiredAt(issuedCoupon.getExpiredAt())

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
@@ -1,0 +1,103 @@
+package com.orderingsystem.coupon.application;
+
+import com.orderingsystem.coupon.application.dto.request.CouponIssueApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
+import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
+import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IssueCouponService {
+
+    private final CouponCachePort couponCachePort;
+    private final CouponRepository couponRepository;
+    private final IssuedCouponRepository issuedCouponRepository;
+    private final CouponIssueMessagePublisher couponIssueMessagePublisher;
+
+    public void requestCouponIssuance(UUID couponId, UUID userId, LocalDateTime issuanceRequestedAt) {
+        ensureCouponExists(couponId, userId);
+        ensureFirstIssue(couponId, userId);
+        Long remainingStock = couponCachePort.decreaseStock(couponId);
+
+        CouponIssuedEvent couponIssuedEvent = CouponIssuedEvent.builder()
+                .couponId(couponId)
+                .createdAt(issuanceRequestedAt)
+                .userId(userId)
+                .build();
+
+        if (remainingStock != null && remainingStock >= 0) {
+            try {
+                couponIssueMessagePublisher.publish(couponIssuedEvent);
+            } catch (Exception e) {
+                //TODO: Kafka 롤백(재고 복구, 중복 이력 삭제)
+                couponCachePort.increaseStock(couponId);
+                couponCachePort.removeIssuedUser(couponId, userId);
+
+                log.warn("쿠폰 발급 중 Kafka 발행 실패로 인한 오류 발생. 롤백 진행. couponId : [{}], userId : [{}]", couponId, userId);
+                throw new RuntimeException("쿠폰 발급 중 오류 발생");
+            }
+        } else {
+            couponCachePort.increaseStock(couponId);
+            couponCachePort.removeIssuedUser(couponId, userId);
+            throw new IllegalArgumentException("쿠폰이 마감되었습니다.");
+        }
+
+        log.info("쿠폰 발급 성공. couponId : [{}], userId : [{}], 남은 재고 : [{}]", couponId, userId, remainingStock);
+    }
+
+    private void ensureCouponExists(UUID couponId, UUID userId) {
+        if (!couponCachePort.exists(couponId)){
+            log.info("존재하지 않는 쿠폰 발급 요청. couponId : [{}], userId : [{}]", couponId, userId);
+            throw new CouponNotFoundException("존재하지 않는 쿠폰입니다.");
+        }
+    }
+
+    private void ensureFirstIssue(UUID couponId, UUID userId) {
+        boolean isNewUser = couponCachePort.addIssuedUser(couponId, userId);
+        if (!isNewUser) {
+            log.warn("이미 쿠폰이 발급된 사용자입니다. couponId:[{}], userId:[{}]", couponId, userId);
+            throw new IllegalArgumentException("이미 쿠폰이 발급되었습니다.");
+        }
+    }
+
+    @Transactional
+    public void saveIssuedCoupon(List<CouponIssueApplicationRequest> requests) {
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        List<IssuedCoupon> issuedCoupons = new ArrayList<>();
+
+        for (CouponIssueApplicationRequest request : requests) {
+            log.info("[{}] 유저에 대한 쿠폰 [{}] 저장.", request.getCouponId(), request.getUserId());
+
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(request.getUserId(), request.getCouponId(),
+                    request.getIssuedAt(), request.getExpiredAt());
+            issuedCoupons.add(issuedCoupon);
+        }
+        issuedCouponRepository.saveAll(issuedCoupons);
+
+        Map<UUID, Long> countMap = requests.stream()
+                .collect(Collectors.groupingBy(CouponIssueApplicationRequest::getCouponId, Collectors.counting()));
+
+        countMap.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> couponRepository.increaseIssuedCount(entry.getKey(), entry.getValue()));
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
@@ -44,7 +44,6 @@ public class IssueCouponService {
             try {
                 couponIssueMessagePublisher.publish(couponIssuedEvent);
             } catch (Exception e) {
-                //TODO: Kafka 롤백(재고 복구, 중복 이력 삭제)
                 couponCachePort.increaseStock(couponId);
                 couponCachePort.removeIssuedUser(couponId, userId);
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
@@ -5,6 +5,7 @@ import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
 import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
@@ -60,7 +61,7 @@ public class IssueCouponService {
     }
 
     private void ensureCouponExists(UUID couponId, UUID userId) {
-        if (!couponCachePort.exists(couponId)){
+        if (!couponCachePort.exists(couponId)) {
             log.info("존재하지 않는 쿠폰 발급 요청. couponId : [{}], userId : [{}]", couponId, userId);
             throw new CouponNotFoundException("존재하지 않는 쿠폰입니다.");
         }
@@ -80,13 +81,30 @@ public class IssueCouponService {
             return;
         }
 
+        List<UUID> couponIds = requests.stream()
+                .map(CouponIssueApplicationRequest::getCouponId)
+                .distinct()
+                .toList();
+
+        Map<UUID, Coupon> couponMap = couponRepository.findAllByCouponIdIn(couponIds).stream()
+                .collect(Collectors.toMap(Coupon::getCouponId, c -> c));
+
         List<IssuedCoupon> issuedCoupons = new ArrayList<>();
 
         for (CouponIssueApplicationRequest request : requests) {
             log.info("[{}] 유저에 대한 쿠폰 [{}] 저장.", request.getCouponId(), request.getUserId());
 
+            Coupon coupon = couponMap.get(request.getCouponId());
+
+            if (coupon == null) {
+                log.error("쿠폰 정보를 찾을 수 없습니다. couponId: {}", request.getCouponId());
+                continue;
+            }
+
+            LocalDateTime expiredAt = request.getIssuedAt().plusDays(coupon.getValidDays());
+
             IssuedCoupon issuedCoupon = IssuedCoupon.create(request.getUserId(), request.getCouponId(),
-                    request.getIssuedAt(), request.getExpiredAt());
+                    request.getIssuedAt(), expiredAt);
             issuedCoupons.add(issuedCoupon);
         }
         issuedCouponRepository.saveAll(issuedCoupons);

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/IssueCouponService.java
@@ -6,6 +6,7 @@ import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublishe
 import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
 import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
@@ -92,7 +93,7 @@ public class IssueCouponService {
         List<IssuedCoupon> issuedCoupons = new ArrayList<>();
 
         for (CouponIssueApplicationRequest request : requests) {
-            log.info("[{}] 유저에 대한 쿠폰 [{}] 저장.", request.getCouponId(), request.getUserId());
+            log.info("[{}] 유저에 대한 쿠폰 [{}] 저장.", request.getUserId(), request.getCouponId());
 
             Coupon coupon = couponMap.get(request.getCouponId());
 
@@ -101,7 +102,11 @@ public class IssueCouponService {
                 continue;
             }
 
-            LocalDateTime expiredAt = request.getIssuedAt().plusDays(coupon.getValidDays());
+            LocalDateTime expiredAt = null;
+
+            if (coupon.getValidDays() != null) {
+                expiredAt = request.getIssuedAt().plusDays(coupon.getValidDays());
+            }
 
             IssuedCoupon issuedCoupon = IssuedCoupon.create(request.getUserId(), request.getCouponId(),
                     request.getIssuedAt(), expiredAt);
@@ -115,6 +120,12 @@ public class IssueCouponService {
         countMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .forEach(entry -> couponRepository.increaseIssuedCount(entry.getKey(), entry.getValue()));
+    }
+
+    @Transactional
+    public void updateCouponStatus(UUID couponId, CouponStatus couponStatus) {
+        couponRepository.updateStatus(couponId, couponStatus);
+        log.info("쿠폰 상태 변경 완료. couponId : [{}], status : {}", couponId, couponStatus);
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CouponIssueApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CouponIssueApplicationRequest.java
@@ -1,0 +1,17 @@
+package com.orderingsystem.coupon.application.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponIssueApplicationRequest {
+
+    private UUID couponId;
+    private UUID userId;
+    private LocalDateTime issuedAt;
+    private LocalDateTime expiredAt;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CouponIssueApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CouponIssueApplicationRequest.java
@@ -12,6 +12,5 @@ public class CouponIssueApplicationRequest {
     private UUID couponId;
     private UUID userId;
     private LocalDateTime issuedAt;
-    private LocalDateTime expiredAt;
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
@@ -1,0 +1,22 @@
+package com.orderingsystem.coupon.application.dto.request;
+
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateCouponApplicationRequest {
+
+    private DiscountType discountType;
+    private BigDecimal amountOff;
+    private Long percentOff;
+    private BigDecimal maxDiscountAmount;
+    private BigDecimal minDiscountAmount;
+    private LocalDateTime validFrom;
+    private LocalDateTime validUntil;
+    private Long issueLimit;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
@@ -5,9 +5,11 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class CreateCouponApplicationRequest {
 
     private DiscountType discountType;

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 public class CreateCouponApplicationRequest {
 
     private DiscountType discountType;
+    private String name;
     private BigDecimal amountOff;
     private Long percentOff;
     private BigDecimal maxDiscountAmount;

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/request/CreateCouponApplicationRequest.java
@@ -21,5 +21,6 @@ public class CreateCouponApplicationRequest {
     private LocalDateTime validFrom;
     private LocalDateTime validUntil;
     private Long issueLimit;
+    private Integer validDays;
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/response/CouponResponse.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/response/CouponResponse.java
@@ -1,0 +1,29 @@
+package com.orderingsystem.coupon.application.dto.response;
+
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponResponse {
+
+    private final UUID couponId;
+    private final String couponName;
+    private final DiscountType discountType;
+    private final CouponStatus couponStatus;
+    private final BigDecimal amountOff;
+    private final Long percentOff;
+    private final BigDecimal maxDiscountAmount;
+    private final BigDecimal minDiscountAmount;
+    private final LocalDateTime validFrom;
+    private final LocalDateTime validUntil;
+    private final Integer validDays;
+    private final Long issueLimit;
+    private final Long issuedCount;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/dto/response/IssuedCouponResponse.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/dto/response/IssuedCouponResponse.java
@@ -1,0 +1,28 @@
+package com.orderingsystem.coupon.application.dto.response;
+
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IssuedCouponResponse {
+
+    private final UUID couponId;
+    private final String couponName;
+    private Long issuedCouponId;
+    private final IssuedCouponStatus issuedCouponStatus;
+    private final LocalDateTime issuedAt;
+    private final LocalDateTime usedAt;
+    private final LocalDateTime expiredAt;
+    private final DiscountType discountType;
+    private final BigDecimal amountOff;
+    private final Long percentOff;
+    private final BigDecimal maxDiscountAmount;
+    private final BigDecimal minOrderAmount;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
@@ -1,5 +1,6 @@
 package com.orderingsystem.coupon.application.port.out;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public interface CouponCachePort {
@@ -17,5 +18,7 @@ public interface CouponCachePort {
     boolean exists(UUID couponId);
 
     void deleteCouponStock(UUID couponId);
+
+    void enableCoupon(UUID couponId, Long issueLimit, LocalDateTime validUntil);
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
@@ -21,4 +21,6 @@ public interface CouponCachePort {
 
     void enableCoupon(UUID couponId, Long issueLimit, LocalDateTime validUntil);
 
+    void setExpireIssuedUserKey(UUID couponId);
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
@@ -1,0 +1,19 @@
+package com.orderingsystem.coupon.application.port.out;
+
+import java.util.UUID;
+
+public interface CouponCachePort {
+
+    long currentStock(UUID couponId);
+
+    Long decreaseStock(UUID couponId);
+
+    Long increaseStock(UUID couponId);
+
+    boolean addIssuedUser(UUID couponId, UUID userId);
+
+    void removeIssuedUser(UUID couponId, UUID userId);
+
+    boolean exists(UUID couponId);
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponCachePort.java
@@ -16,4 +16,6 @@ public interface CouponCachePort {
 
     boolean exists(UUID couponId);
 
+    void deleteCouponStock(UUID couponId);
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponIssueMessagePublisher.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponIssueMessagePublisher.java
@@ -1,0 +1,7 @@
+package com.orderingsystem.coupon.application.port.out;
+
+import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
+
+public interface CouponIssueMessagePublisher {
+    void publish(CouponIssuedEvent event);
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponSchedulerPort.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/application/port/out/CouponSchedulerPort.java
@@ -1,0 +1,10 @@
+package com.orderingsystem.coupon.application.port.out;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface CouponSchedulerPort {
+
+    void scheduleCouponStart(UUID couponId, Long issueLimit, LocalDateTime validFrom, LocalDateTime validUntil);
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/event/CouponIssuedEvent.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/event/CouponIssuedEvent.java
@@ -1,0 +1,16 @@
+package com.orderingsystem.coupon.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponIssuedEvent {
+
+    private final UUID couponId;
+    private final UUID userId;
+    private final LocalDateTime createdAt;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/exception/CouponNotFoundException.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/exception/CouponNotFoundException.java
@@ -1,0 +1,9 @@
+package com.orderingsystem.coupon.domain.exception;
+
+import com.orderingsystem.common.exception.NotFoundException;
+
+public class CouponNotFoundException extends NotFoundException {
+    public CouponNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -64,5 +65,37 @@ public class Coupon extends AggregateRoot {
 
     @PositiveOrZero
     private Long issuedCount;
+
+    public static Coupon create(DiscountType discountType, BigDecimal amountOff, Long percentOff,
+                                BigDecimal maxDiscountAmount, BigDecimal minDiscountAmount, LocalDateTime validFrom,
+                                LocalDateTime validUntil, Long issueLimit) {
+        return Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .discountType(discountType)
+                .status(CouponStatus.SCHEDULED)
+                .amountOff(amountOff)
+                .percentOff(percentOff)
+                .maxDiscountAmount(maxDiscountAmount)
+                .minDiscountAmount(minDiscountAmount)
+                .validFrom(validFrom)
+                .validUntil(validUntil)
+                .issueLimit(issueLimit)
+                .issuedCount(0L)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Coupon coupon = (Coupon) o;
+        return Objects.equals(couponId, coupon.couponId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(couponId);
+    }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -108,6 +108,16 @@ public class Coupon extends AggregateRoot {
         this.status = CouponStatus.ARCHIVED;
     }
 
+    public CouponStatus getDisplayStatus() {
+        LocalDateTime now = LocalDateTime.now();
+        if (this.status == CouponStatus.ACTIVE
+                && this.validUntil != null
+                && this.validUntil.isBefore(now)) {
+            return CouponStatus.EXPIRED;
+        }
+        return this.status;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -84,6 +84,10 @@ public class Coupon extends AggregateRoot {
                 .build();
     }
 
+    public void increaseIssuedCount() {
+        this.issuedCount++;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {
@@ -97,5 +101,4 @@ public class Coupon extends AggregateRoot {
     public int hashCode() {
         return Objects.hashCode(couponId);
     }
-
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -97,6 +97,13 @@ public class Coupon extends AggregateRoot {
         this.status = CouponStatus.PAUSED;
     }
 
+    public void resume() {
+        if (this.status != CouponStatus.PAUSED) {
+            throw new IllegalStateException("정지된 쿠폰만 재시작할 수 있습니다.");
+        }
+        this.status = CouponStatus.ACTIVE;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -104,6 +104,10 @@ public class Coupon extends AggregateRoot {
         this.status = CouponStatus.ACTIVE;
     }
 
+    public void terminate() {
+        this.status = CouponStatus.ARCHIVED;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -93,6 +93,10 @@ public class Coupon extends AggregateRoot {
         this.issuedCount++;
     }
 
+    public void pause() {
+        this.status = CouponStatus.PAUSED;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -61,6 +61,7 @@ public class Coupon extends AggregateRoot {
 
     private LocalDateTime validFrom;
     private LocalDateTime validUntil;
+    private Integer validDays;
 
     @PositiveOrZero
     private Long issueLimit;
@@ -70,7 +71,7 @@ public class Coupon extends AggregateRoot {
 
     public static Coupon create(DiscountType discountType, BigDecimal amountOff, Long percentOff,
                                 BigDecimal maxDiscountAmount, BigDecimal minDiscountAmount, LocalDateTime validFrom,
-                                LocalDateTime validUntil, Long issueLimit, String name) {
+                                LocalDateTime validUntil, Long issueLimit, String name, Integer validDays) {
         return Coupon.builder()
                 .couponId(UUID.randomUUID())
                 .discountType(discountType)
@@ -84,6 +85,7 @@ public class Coupon extends AggregateRoot {
                 .issueLimit(issueLimit)
                 .issuedCount(0L)
                 .name(name)
+                .validDays(validDays)
                 .build();
     }
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -70,7 +70,7 @@ public class Coupon extends AggregateRoot {
 
     public static Coupon create(DiscountType discountType, BigDecimal amountOff, Long percentOff,
                                 BigDecimal maxDiscountAmount, BigDecimal minDiscountAmount, LocalDateTime validFrom,
-                                LocalDateTime validUntil, Long issueLimit) {
+                                LocalDateTime validUntil, Long issueLimit, String name) {
         return Coupon.builder()
                 .couponId(UUID.randomUUID())
                 .discountType(discountType)
@@ -83,6 +83,7 @@ public class Coupon extends AggregateRoot {
                 .validUntil(validUntil)
                 .issueLimit(issueLimit)
                 .issuedCount(0L)
+                .name(name)
                 .build();
     }
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -33,6 +33,8 @@ public class Coupon extends AggregateRoot {
     @Id
     private UUID couponId;
 
+    private String name;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DiscountType discountType;

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/Coupon.java
@@ -1,0 +1,68 @@
+package com.orderingsystem.coupon.domain.model;
+
+import com.orderingsystem.common.domain.AggregateRoot;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "coupons")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@Getter
+@Builder
+public class Coupon extends AggregateRoot {
+
+    @Id
+    private UUID couponId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiscountType discountType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CouponStatus status;
+
+    @Column(precision = 19, scale = 2)
+    @PositiveOrZero
+    private BigDecimal amountOff;
+
+    @Min(0)
+    @Max(100)
+    private Long percentOff;
+
+    @Column(precision = 19, scale = 2)
+    @PositiveOrZero
+    private BigDecimal maxDiscountAmount;
+
+    @Column(precision = 19, scale = 2)
+    @PositiveOrZero
+    private BigDecimal minDiscountAmount;
+
+    private LocalDateTime validFrom;
+    private LocalDateTime validUntil;
+
+    @PositiveOrZero
+    private Long issueLimit;
+
+    @PositiveOrZero
+    private Long issuedCount;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/CouponStatus.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/CouponStatus.java
@@ -1,0 +1,5 @@
+package com.orderingsystem.coupon.domain.model;
+
+public enum CouponStatus {
+    ACTIVE, SCHEDULED, PAUSED, EXPIRED, ARCHIVED
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/DiscountType.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/DiscountType.java
@@ -1,0 +1,5 @@
+package com.orderingsystem.coupon.domain.model;
+
+public enum DiscountType {
+    PERCENTAGE, FIXED_AMOUNT
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
@@ -37,7 +37,6 @@ public class IssuedCoupon extends BaseEntity {
     @Column(nullable = false)
     private UUID couponId;
 
-    @Column(nullable = false)
     private UUID orderId;
 
     @Enumerated(EnumType.STRING)
@@ -48,5 +47,15 @@ public class IssuedCoupon extends BaseEntity {
 
     private LocalDateTime usedAt;
     private LocalDateTime expiredAt;
+
+    public static IssuedCoupon create(UUID userId, UUID couponId, LocalDateTime issuedAt, LocalDateTime expiredAt) {
+        return IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(couponId)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(issuedAt)
+                .expiredAt(expiredAt)
+                .build();
+    }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
@@ -58,4 +58,13 @@ public class IssuedCoupon extends BaseEntity {
                 .build();
     }
 
+    public IssuedCouponStatus getDisplayStatus() {
+        if (this.status == IssuedCouponStatus.ISSUED
+                && this.expiredAt != null
+                && this.expiredAt.isBefore(LocalDateTime.now())) {
+            return IssuedCouponStatus.EXPIRED;
+        }
+        return this.status;
+    }
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCoupon.java
@@ -1,0 +1,52 @@
+package com.orderingsystem.coupon.domain.model;
+
+import com.orderingsystem.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "issued_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@Getter
+@Builder
+public class IssuedCoupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private UUID couponId;
+
+    @Column(nullable = false)
+    private UUID orderId;
+
+    @Enumerated(EnumType.STRING)
+    private IssuedCouponStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime usedAt;
+    private LocalDateTime expiredAt;
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCouponStatus.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCouponStatus.java
@@ -1,5 +1,5 @@
 package com.orderingsystem.coupon.domain.model;
 
 public enum IssuedCouponStatus {
-    ISSUED, LOCKED, USED, RELEASED, EXPIRED, REVOKED
+    ISSUED, USED, EXPIRED, REVOKED
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCouponStatus.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/model/IssuedCouponStatus.java
@@ -1,0 +1,5 @@
+package com.orderingsystem.coupon.domain.model;
+
+public enum IssuedCouponStatus {
+    ISSUED, LOCKED, USED, RELEASED, EXPIRED, REVOKED
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -3,6 +3,7 @@ package com.orderingsystem.coupon.domain.repository;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface CouponRepository extends JpaRepository<Coupon, UUID> {
     void updateStatus(UUID couponId, CouponStatus couponStatus);
 
     List<Coupon> findAllByStatusAndValidUntilAfter(CouponStatus status, LocalDateTime validUntilAfter);
+
+    List<Coupon> findAllByStatusIn(Collection<CouponStatus> statuses);
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -1,0 +1,8 @@
+package com.orderingsystem.coupon.domain.repository;
+
+import com.orderingsystem.coupon.domain.model.Coupon;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, UUID> {
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -1,6 +1,7 @@
 package com.orderingsystem.coupon.domain.repository;
 
 import com.orderingsystem.coupon.domain.model.Coupon;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,5 +13,7 @@ public interface CouponRepository extends JpaRepository<Coupon, UUID> {
     @Modifying
     @Query("UPDATE Coupon  c SET c.issuedCount = c.issuedCount + :count WHERE c.couponId = :couponId")
     void increaseIssuedCount(@Param("couponId") UUID couponId, @Param("count") Long count);
+
+    List<Coupon> findAllByCouponIdIn(List<UUID> couponId);
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -1,6 +1,8 @@
 package com.orderingsystem.coupon.domain.repository;
 
 import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +18,9 @@ public interface CouponRepository extends JpaRepository<Coupon, UUID> {
 
     List<Coupon> findAllByCouponIdIn(List<UUID> couponId);
 
+    @Modifying
+    @Query("UPDATE Coupon  c SET c.status = :couponStatus WHERE c.couponId = :couponId")
+    void updateStatus(UUID couponId, CouponStatus couponStatus);
+
+    List<Coupon> findAllByStatusAndValidUntilAfter(CouponStatus status, LocalDateTime validUntilAfter);
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -3,6 +3,14 @@ package com.orderingsystem.coupon.domain.repository;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CouponRepository extends JpaRepository<Coupon, UUID> {
+
+    @Modifying
+    @Query("UPDATE Coupon  c SET c.issuedCount = c.issuedCount + :count WHERE c.couponId = :couponId")
+    void increaseIssuedCount(@Param("couponId") UUID couponId, @Param("count") Long count);
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/CouponRepository.java
@@ -26,4 +26,9 @@ public interface CouponRepository extends JpaRepository<Coupon, UUID> {
     List<Coupon> findAllByStatusAndValidUntilAfter(CouponStatus status, LocalDateTime validUntilAfter);
 
     List<Coupon> findAllByStatusIn(Collection<CouponStatus> statuses);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Coupon c SET c.status = 'EXPIRED' WHERE c.validUntil < :now AND c.status != 'EXPIRED'")
+    int bulkExpireCoupons(LocalDateTime now);
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
@@ -2,12 +2,19 @@ package com.orderingsystem.coupon.domain.repository;
 
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
 
     List<IssuedCoupon> findByUserIdAndStatusIn(UUID userId, List<IssuedCouponStatus> statuses);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE IssuedCoupon ic SET ic.status = 'EXPIRED' WHERE ic.expiredAt < :now AND ic.status = 'ISSUED'")
+    int bulkExpireIssuedCoupons(LocalDateTime now);
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
@@ -1,0 +1,7 @@
+package com.orderingsystem.coupon.domain.repository;
+
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
@@ -3,6 +3,7 @@ package com.orderingsystem.coupon.domain.repository;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
 
-    List<IssuedCoupon> findByUserIdAndStatusIn(UUID userId, List<IssuedCouponStatus> statuses);
+    List<IssuedCoupon> findByUserIdAndStatusIn(UUID userId, Collection<IssuedCouponStatus> statuses);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE IssuedCoupon ic SET ic.status = 'EXPIRED' WHERE ic.expiredAt < :now AND ic.status = 'ISSUED'")

--- a/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepository.java
@@ -1,7 +1,13 @@
 package com.orderingsystem.coupon.domain.repository;
 
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
+
+    List<IssuedCoupon> findByUserIdAndStatusIn(UUID userId, List<IssuedCouponStatus> statuses);
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/listener/CouponIssueMessageKafkaListener.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/listener/CouponIssueMessageKafkaListener.java
@@ -1,0 +1,56 @@
+package com.orderingsystem.coupon.infra.kafka.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.orderingsystem.coupon.application.IssueCouponService;
+import com.orderingsystem.coupon.application.dto.request.CouponIssueApplicationRequest;
+import com.orderingsystem.coupon.infra.kafka.message.CouponIssueMessage;
+import com.orderingsystem.kafka.KafkaConsumer;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CouponIssueMessageKafkaListener implements KafkaConsumer<String> {
+
+    private final IssueCouponService issueCouponService;
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Override
+    @KafkaListener(id = "${kafka-consumer-config.coupon-group-id}",
+            topics = "${coupon-service.coupon-issue-topic-name}")
+    public void receive(@Payload List<String> messages,
+                        @Header(KafkaHeaders.RECEIVED_KEY) List<String> keys,
+                        @Header(KafkaHeaders.RECEIVED_PARTITION) List<Integer> partitions,
+                        @Header(KafkaHeaders.OFFSET) List<Long> offsets) {
+        log.info("쿠폰 발급 요청 {}건 수신. keys:{}, partitions:{}, offsets:{}",
+                messages.size(), keys, partitions, offsets);
+
+        List<CouponIssueApplicationRequest> requests = new ArrayList<>();
+
+        for (String json : messages) {
+            try {
+                CouponIssueMessage message = objectMapper.readValue(json, CouponIssueMessage.class);
+                requests.add(message.toCouponIssueApplicationRequest());
+            } catch (JsonProcessingException e) {
+                log.error("JSON 파싱 실패. data: {}", json, e);
+            }
+        }
+
+        if (!requests.isEmpty()) {
+            issueCouponService.saveIssuedCoupon(requests);
+            log.info("쿠폰 발급 배치 처리 완료: {}건", requests.size());
+        }
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/message/CouponIssueMessage.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/message/CouponIssueMessage.java
@@ -1,0 +1,29 @@
+package com.orderingsystem.coupon.infra.kafka.message;
+
+import com.orderingsystem.coupon.application.dto.request.CouponIssueApplicationRequest;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CouponIssueMessage {
+
+    private UUID couponId;
+    private UUID userId;
+    private LocalDateTime issuedAt;
+
+    public CouponIssueApplicationRequest toCouponIssueApplicationRequest(){
+        return CouponIssueApplicationRequest.builder()
+                .couponId(this.couponId)
+                .userId(this.userId)
+                .issuedAt(this.issuedAt)
+                .build();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/publisher/CouponIssueKafkaMessagePublisher.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/kafka/publisher/CouponIssueKafkaMessagePublisher.java
@@ -1,0 +1,62 @@
+package com.orderingsystem.coupon.infra.kafka.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
+import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
+import com.orderingsystem.coupon.infra.kafka.message.CouponIssueMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CouponIssueKafkaMessagePublisher implements CouponIssueMessagePublisher {
+
+    private final KafkaTemplate<String, String> kafkaProducer;
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Value("${coupon-service.coupon-issue-topic-name}")
+    public String topicName;
+
+    @Override
+    public void publish(CouponIssuedEvent event) {
+        String key = event.getUserId().toString();
+        CouponIssueMessage couponIssueMessage = buildMessage(event);
+
+        log.info("CouponIssueKafkaMessagePublisher request 전송 시작. topic : {}, key : {}", topicName, key);
+
+        try {
+            String message = objectMapper.writeValueAsString(couponIssueMessage);
+            kafkaProducer.send(topicName, key, message)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            log.info("CouponIssueKafkaMessagePublisher Kafka Message 전송 성공. Offset : {}",
+                                    result.getRecordMetadata().offset());
+                        } else {
+                            log.error("CouponIssueKafkaMessagePublisher Kafka Message 전송 실패.", ex);
+                        }
+                    });
+        } catch (JsonProcessingException e) {
+            log.error("CouponIssueKafkaMessagePublisher json 변환 에러", e);
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            log.error("CouponIssueKafkaMessagePublisher Error publishing Message", e);
+            throw new RuntimeException("Kafka publish 실패", e);
+        }
+    }
+
+    private CouponIssueMessage buildMessage(CouponIssuedEvent event) {
+        return CouponIssueMessage.builder()
+                .couponId(event.getCouponId())
+                .userId(event.getUserId())
+                .issuedAt(event.getCreatedAt())
+                .build();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
@@ -69,6 +69,7 @@ public class RedisCouponRepository implements CouponCachePort {
         redisTemplate.delete(stockKey(couponId));
     }
 
+    @Override
     public void enableCoupon(UUID couponId, Long issueLimit, LocalDateTime validUntil) {
         String key = stockKey(couponId);
         String value = issueLimit.toString();

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
@@ -1,0 +1,64 @@
+package com.orderingsystem.coupon.infra.redis;
+
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class RedisCouponRepository implements CouponCachePort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${coupon.redis.stock-prefix}")
+    private String stockPrefix;
+
+    @Value("${coupon.redis.issued-prefix}")
+    private String issuedPrefix;
+
+    private String stockKey(UUID couponId) {
+        return stockPrefix + couponId;
+    }
+
+    private String issuedKey(UUID couponId) {
+        return issuedPrefix + couponId;
+    }
+
+    @Override
+    public long currentStock(UUID couponId) {
+        String stock = redisTemplate.opsForValue().get(stockKey(couponId));
+        return stock == null ? 0L : Long.parseLong(stock);
+    }
+
+    @Override
+    public Long decreaseStock(UUID couponId) {
+        return redisTemplate.opsForValue().decrement(stockKey(couponId));
+    }
+
+    @Override
+    public Long increaseStock(UUID couponId) {
+        return redisTemplate.opsForValue().increment(stockKey(couponId));
+    }
+
+    @Override
+    public boolean addIssuedUser(UUID couponId, UUID userId) {
+        Long result = redisTemplate.opsForSet().add(issuedKey(couponId), userId.toString());
+        return result != null && result == 1L;
+    }
+
+    @Override
+    public void removeIssuedUser(UUID couponId, UUID userId) {
+        redisTemplate.opsForSet().remove(issuedKey(couponId), userId.toString());
+    }
+
+    @Override
+    public boolean exists(UUID couponId) {
+        return redisTemplate.hasKey(stockKey(couponId));
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
@@ -64,6 +64,11 @@ public class RedisCouponRepository implements CouponCachePort {
         return redisTemplate.hasKey(stockKey(couponId));
     }
 
+    @Override
+    public void deleteCouponStock(UUID couponId) {
+        redisTemplate.delete(stockKey(couponId));
+    }
+
     public void enableCoupon(UUID couponId, Long issueLimit, LocalDateTime validUntil) {
         String key = stockKey(couponId);
         String value = issueLimit.toString();

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
@@ -86,4 +86,10 @@ public class RedisCouponRepository implements CouponCachePort {
         redisTemplate.opsForValue().set(key, value);
     }
 
+    @Override
+    public void setExpireIssuedUserKey(UUID couponId) {
+        String key = issuedKey(couponId);
+        redisTemplate.expire(key, 7, TimeUnit.DAYS);
+    }
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/redis/RedisCouponRepository.java
@@ -1,7 +1,10 @@
 package com.orderingsystem.coupon.infra.redis;
 
 import com.orderingsystem.coupon.application.port.out.CouponCachePort;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,6 +62,22 @@ public class RedisCouponRepository implements CouponCachePort {
     @Override
     public boolean exists(UUID couponId) {
         return redisTemplate.hasKey(stockKey(couponId));
+    }
+
+    public void enableCoupon(UUID couponId, Long issueLimit, LocalDateTime validUntil) {
+        String key = stockKey(couponId);
+        String value = issueLimit.toString();
+
+        if (validUntil != null) {
+            long ttlSeconds = Duration.between(LocalDateTime.now(), validUntil).getSeconds();
+
+            if (ttlSeconds > 0) {
+                redisTemplate.opsForValue().set(key, value, ttlSeconds, TimeUnit.SECONDS);
+                return;
+            }
+        }
+
+        redisTemplate.opsForValue().set(key, value);
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponDistributionScheduler.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponDistributionScheduler.java
@@ -1,0 +1,48 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import com.orderingsystem.coupon.application.IssueCouponService;
+import com.orderingsystem.coupon.application.port.out.CouponSchedulerPort;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.infra.redis.RedisCouponRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponDistributionScheduler implements CouponSchedulerPort {
+
+    private final TaskScheduler taskScheduler;
+    private final RedisCouponRepository redisCouponRepository;
+    private final IssueCouponService issueCouponService;
+
+    @Override
+    public void scheduleCouponStart(UUID couponId, Long issueLimit, LocalDateTime validFrom, LocalDateTime validUntil) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (validFrom.isBefore(now)) {
+            registerToRedis(couponId, issueLimit, validUntil);
+        } else {
+            Instant startTime = validFrom.atZone(ZoneId.systemDefault()).toInstant();
+
+            taskScheduler.schedule(() -> {
+                log.info("예약 쿠폰 배포 시작. couponId : [{}]", couponId);
+                registerToRedis(couponId, issueLimit, validUntil);
+            }, startTime);
+
+            log.info("쿠폰 배포 예약 완료. 실행 시간 : [{}], couponId : [{}]", validFrom, couponId);
+        }
+    }
+
+    private void registerToRedis(UUID couponId, Long issueLimit, LocalDateTime validUntil) {
+        redisCouponRepository.enableCoupon(couponId, issueLimit, validUntil);
+        issueCouponService.updateCouponStatus(couponId, CouponStatus.ACTIVE);
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationScheduler.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationScheduler.java
@@ -1,6 +1,7 @@
 package com.orderingsystem.coupon.infra.scheduler;
 
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,15 +15,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponExpirationScheduler {
 
     private final CouponRepository couponRepository;
+    private final IssuedCouponRepository issuedCouponRepository;
 
     @Scheduled(cron = "${scheduler.coupon.expiration}")
     @Transactional
-    public void expireCoupons(){
-        log.info("쿠폰 만료 정리 배치 처리 시작...");
+    public void expireCoupons() {
+        LocalDateTime now = LocalDateTime.now();
 
-        int count = couponRepository.bulkExpireCoupons(LocalDateTime.now());
+        log.info("쿠폰 만료 정리 배치 처리 시작... (기준 시각 : [{}])", now);
 
-        log.info("총 {}개의 만료된 쿠폰을 EXPIRED 상태로 변경.", count);
+        int expiredCouponCount = couponRepository.bulkExpireCoupons(now);
+        int expiredIssuedCouponCount = issuedCouponRepository.bulkExpireIssuedCoupons(now);
+
+        log.info("총 {}개의 만료된 쿠폰, {}개의 만료된 발급 쿠폰을 EXPIRED 상태로 변경.", expiredCouponCount, expiredIssuedCouponCount);
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationScheduler.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationScheduler.java
@@ -1,0 +1,28 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponExpirationScheduler {
+
+    private final CouponRepository couponRepository;
+
+    @Scheduled(cron = "${scheduler.coupon.expiration}")
+    @Transactional
+    public void expireCoupons(){
+        log.info("쿠폰 만료 정리 배치 처리 시작...");
+
+        int count = couponRepository.bulkExpireCoupons(LocalDateTime.now());
+
+        log.info("총 {}개의 만료된 쿠폰을 EXPIRED 상태로 변경.", count);
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponStartRunner.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/infra/scheduler/CouponStartRunner.java
@@ -1,0 +1,36 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponStartRunner implements ApplicationRunner {
+
+    private final CouponRepository couponRepository;
+    private final CouponDistributionScheduler couponDistributionScheduler;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("서버 재시작. 예정된 쿠폰 스케줄 복구 시작.");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Coupon> futureCoupons = couponRepository.findAllByStatusAndValidUntilAfter(CouponStatus.SCHEDULED, now);
+
+        for (Coupon coupon : futureCoupons) {
+            couponDistributionScheduler.scheduleCouponStart(coupon.getCouponId(), coupon.getIssueLimit(),
+                    coupon.getValidFrom(), coupon.getValidUntil());
+        }
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -7,6 +7,7 @@ import com.orderingsystem.coupon.application.FindCouponService;
 import com.orderingsystem.coupon.application.IssueCouponService;
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
@@ -67,6 +68,13 @@ public class CouponController {
                                                            @RequestParam(value = "status", defaultValue = "ACTIVE") List<CouponStatus> couponStatuses) {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         return ResponseEntity.ok(findCouponService.getCoupons(userId, couponStatuses));
+    }
+
+    @GetMapping("/{couponId}")
+    public ResponseEntity<CouponResponse> getCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable UUID couponId) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        return ResponseEntity.ok(findCouponService.getCoupon(userId, couponId));
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -5,7 +5,9 @@ import com.orderingsystem.common.util.CommonJwtUtil;
 import com.orderingsystem.coupon.application.CouponFacade;
 import com.orderingsystem.coupon.application.FindCouponService;
 import com.orderingsystem.coupon.application.IssueCouponService;
+import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
 import jakarta.validation.Valid;
@@ -58,6 +60,13 @@ public class CouponController {
             @RequestParam(value = "status", defaultValue = "ISSUED") List<IssuedCouponStatus> couponStatuses) {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         return ResponseEntity.ok(findCouponService.getIssuedCoupons(userId, couponStatuses));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CouponResponse>> getCoupons(@RequestHeader("Authorization") String authorizationHeader,
+                                                           @RequestParam(value = "status", defaultValue = "ACTIVE") List<CouponStatus> couponStatuses) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        return ResponseEntity.ok(findCouponService.getCoupons(userId, couponStatuses));
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -5,10 +5,10 @@ import com.orderingsystem.common.util.CommonJwtUtil;
 import com.orderingsystem.coupon.application.CouponFacade;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
 import jakarta.validation.Valid;
+import java.net.URI;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -28,8 +28,8 @@ public class CouponController {
                                              @RequestBody @Valid CreateCouponRequest createCouponRequest) {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
-        couponFacade.createCoupon(createCouponRequest.toApplicationRequest(), userType, userId);
-        return ResponseEntity.ok().build();
+        UUID couponId = couponFacade.createCoupon(createCouponRequest.toApplicationRequest(), userType, userId);
+        return ResponseEntity.created(URI.create("/api/coupons/"+couponId)).build();
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -7,7 +7,6 @@ import com.orderingsystem.coupon.application.FindCouponService;
 import com.orderingsystem.coupon.application.IssueCouponService;
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
-import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
@@ -72,9 +71,16 @@ public class CouponController {
 
     @GetMapping("/{couponId}")
     public ResponseEntity<CouponResponse> getCoupon(@RequestHeader("Authorization") String authorizationHeader,
-                                            @PathVariable UUID couponId) {
+                                                    @PathVariable UUID couponId) {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         return ResponseEntity.ok(findCouponService.getCoupon(userId, couponId));
+    }
+
+    @GetMapping("/issued/{issuedCouponId}")
+    public ResponseEntity<IssuedCouponResponse> getIssuedCoupon(
+            @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long issuedCouponId) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        return ResponseEntity.ok(findCouponService.getIssuedCoupon(userId, issuedCouponId));
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -3,19 +3,25 @@ package com.orderingsystem.coupon.presentation;
 import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.common.util.CommonJwtUtil;
 import com.orderingsystem.coupon.application.CouponFacade;
+import com.orderingsystem.coupon.application.FindCouponService;
 import com.orderingsystem.coupon.application.IssueCouponService;
+import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,6 +32,7 @@ public class CouponController {
     private final CommonJwtUtil commonJwtUtil;
     private final CouponFacade couponFacade;
     private final IssueCouponService issueCouponService;
+    private final FindCouponService findCouponService;
 
     @PostMapping
     public ResponseEntity<Void> createCoupon(@RequestHeader("Authorization") String authorizationHeader,
@@ -33,16 +40,24 @@ public class CouponController {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
         UUID couponId = couponFacade.createCoupon(createCouponRequest.toApplicationRequest(), userType, userId);
-        return ResponseEntity.created(URI.create("/api/coupons/"+couponId)).build();
+        return ResponseEntity.created(URI.create("/api/coupons/" + couponId)).build();
     }
 
     @PostMapping("/{couponId}/claims")
     public ResponseEntity<Void> issueCoupon(@RequestHeader("Authorization") String authorizationHeader,
-                                            @PathVariable UUID couponId){
+                                            @PathVariable UUID couponId) {
         LocalDateTime issuanceRequestedAt = LocalDateTime.now();
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         issueCouponService.requestCouponIssuance(couponId, userId, issuanceRequestedAt);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/issued")
+    public ResponseEntity<List<IssuedCouponResponse>> getIssuedCoupons(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "status", defaultValue = "ISSUED") List<IssuedCouponStatus> couponStatuses) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        return ResponseEntity.ok(findCouponService.getIssuedCoupons(userId, couponStatuses));
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -1,0 +1,35 @@
+package com.orderingsystem.coupon.presentation;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.common.util.CommonJwtUtil;
+import com.orderingsystem.coupon.application.CouponFacade;
+import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponController {
+
+    private final CommonJwtUtil commonJwtUtil;
+    private final CouponFacade couponFacade;
+
+    @PostMapping
+    public ResponseEntity<Void> createCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                             @RequestBody @Valid CreateCouponRequest createCouponRequest) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
+        couponFacade.createCoupon(createCouponRequest.toApplicationRequest(), userType, userId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponController.java
@@ -3,12 +3,15 @@ package com.orderingsystem.coupon.presentation;
 import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.common.util.CommonJwtUtil;
 import com.orderingsystem.coupon.application.CouponFacade;
+import com.orderingsystem.coupon.application.IssueCouponService;
 import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,6 +25,7 @@ public class CouponController {
 
     private final CommonJwtUtil commonJwtUtil;
     private final CouponFacade couponFacade;
+    private final IssueCouponService issueCouponService;
 
     @PostMapping
     public ResponseEntity<Void> createCoupon(@RequestHeader("Authorization") String authorizationHeader,
@@ -30,6 +34,15 @@ public class CouponController {
         UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
         UUID couponId = couponFacade.createCoupon(createCouponRequest.toApplicationRequest(), userType, userId);
         return ResponseEntity.created(URI.create("/api/coupons/"+couponId)).build();
+    }
+
+    @PostMapping("/{couponId}/claims")
+    public ResponseEntity<Void> issueCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable UUID couponId){
+        LocalDateTime issuanceRequestedAt = LocalDateTime.now();
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        issueCouponService.requestCouponIssuance(couponId, userId, issuanceRequestedAt);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
@@ -1,0 +1,32 @@
+package com.orderingsystem.coupon.presentation;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.common.util.CommonJwtUtil;
+import com.orderingsystem.coupon.application.CouponFacade;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponManagementController {
+
+    private final CommonJwtUtil commonJwtUtil;
+    private final CouponFacade couponFacade;
+
+    @PostMapping("/{couponId}/pause")
+    public ResponseEntity<Void> pauseCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable UUID couponId) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
+        couponFacade.pauseCoupon(couponId, userId, userType);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
@@ -31,10 +31,19 @@ public class CouponManagementController {
 
     @PostMapping("/{couponId}/resume")
     public ResponseEntity<Void> resumeCoupon(@RequestHeader("Authorization") String authorizationHeader,
-                                            @PathVariable UUID couponId) {
+                                             @PathVariable UUID couponId) {
         UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
         UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
         couponFacade.resumeCoupon(couponId, userId, userType);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{couponId}/terminate")
+    public ResponseEntity<Void> terminateCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                                @PathVariable UUID couponId) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
+        couponFacade.terminateCoupon(couponId, userId, userType);
         return ResponseEntity.ok().build();
     }
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/CouponManagementController.java
@@ -29,4 +29,13 @@ public class CouponManagementController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/{couponId}/resume")
+    public ResponseEntity<Void> resumeCoupon(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable UUID couponId) {
+        UUID userId = commonJwtUtil.getUserIdFromToken(authorizationHeader);
+        UserType userType = commonJwtUtil.getUserRoleFromToken(authorizationHeader);
+        couponFacade.resumeCoupon(couponId, userId, userType);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
@@ -1,0 +1,79 @@
+package com.orderingsystem.coupon.presentation.request;
+
+import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateCouponRequest {
+
+    @NotNull(message = "쿠폰 타입은 필수입니다.")
+    private DiscountType discountType;
+
+    @PositiveOrZero(message = "할인 금액은 0 이상이어야 합니다.")
+    private BigDecimal amountOff;
+
+    @Min(value = 1, message = "할인율은 1 이상이어야 합니다.")
+    @Max(value = 100, message = "할인율은 100 이하여야 합니다.")
+    private Long percentOff;
+
+    @PositiveOrZero(message = "최대 할인 금액은 0 이상이어야 합니다.")
+    private BigDecimal maxDiscountAmount;
+
+    @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다.")
+    private BigDecimal minDiscountAmount;
+
+    @NotNull(message = "쿠폰 발행 시작 시간은 필수입니다.")
+    private LocalDateTime validFrom;
+
+    private LocalDateTime validUntil;
+
+    @PositiveOrZero(message = "발행 개수는 0 이상이어야 합니다.")
+    private Long issueLimit;
+
+    @AssertTrue(message = "쿠폰 타입이 FIXED_AMOUNT면 amountOff가 필수이며 percentOff, maxDiscountAmount는 비워야 합니다.")
+    private boolean isAmountRuleOk() {
+        if (discountType == null) return true;
+        if (discountType == DiscountType.FIXED_AMOUNT) {
+            return amountOff != null && percentOff == null && maxDiscountAmount == null;
+        }
+        return true;
+    }
+
+    @AssertTrue(message = "타입이 PERCENTAGE면 percentOff가 필수이며 amountOff는 비워야 합니다.")
+    private boolean isPercentRuleOk() {
+        if (discountType == null) return true;
+        if (discountType == DiscountType.PERCENTAGE) {
+            return percentOff != null && amountOff == null;
+        }
+        return true;
+    }
+
+    @AssertTrue(message = "유효기간 종료는 시작 이후여야 합니다.")
+    private boolean isPeriodValid() {
+        return validFrom == null || validUntil == null || validUntil.isAfter(validFrom);
+    }
+
+    public CreateCouponApplicationRequest toApplicationRequest(){
+        return CreateCouponApplicationRequest.builder()
+                .discountType(this.discountType)
+                .amountOff(this.amountOff)
+                .percentOff(this.percentOff)
+                .maxDiscountAmount(this.maxDiscountAmount)
+                .minDiscountAmount(this.minDiscountAmount)
+                .validFrom(this.validFrom)
+                .validUntil(this.validUntil)
+                .issueLimit(this.issueLimit)
+                .build();
+    }
+
+}

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -40,6 +41,9 @@ public class CreateCouponRequest {
     private LocalDateTime validFrom;
 
     private LocalDateTime validUntil;
+
+    @Positive(message = "유효 기간은 1일 이상이어야 합니다.")
+    private Integer validDays;
 
     @PositiveOrZero(message = "발행 개수는 0 이상이어야 합니다.")
     private Long issueLimit;
@@ -78,6 +82,7 @@ public class CreateCouponRequest {
                 .validUntil(this.validUntil)
                 .issueLimit(this.issueLimit)
                 .name(this.name)
+                .validDays(this.validDays)
                 .build();
     }
 

--- a/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
+++ b/coupon/src/main/java/com/orderingsystem/coupon/presentation/request/CreateCouponRequest.java
@@ -5,6 +5,7 @@ import com.orderingsystem.coupon.domain.model.DiscountType;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
@@ -18,6 +19,9 @@ public class CreateCouponRequest {
 
     @NotNull(message = "쿠폰 타입은 필수입니다.")
     private DiscountType discountType;
+
+    @NotBlank(message = "쿠폰 이름은 필수입니다.")
+    private String name;
 
     @PositiveOrZero(message = "할인 금액은 0 이상이어야 합니다.")
     private BigDecimal amountOff;
@@ -73,6 +77,7 @@ public class CreateCouponRequest {
                 .validFrom(this.validFrom)
                 .validUntil(this.validUntil)
                 .issueLimit(this.issueLimit)
+                .name(this.name)
                 .build();
     }
 

--- a/coupon/src/test/java/com/food/ordering/system/coupon/CouponApplicationTests.java
+++ b/coupon/src/test/java/com/food/ordering/system/coupon/CouponApplicationTests.java
@@ -1,0 +1,13 @@
+package com.food.ordering.system.coupon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/CouponApplicationTests.java
+++ b/coupon/src/test/java/com/orderingsystem/CouponApplicationTests.java
@@ -1,9 +1,11 @@
-package com.food.ordering.system.coupon;
+package com.orderingsystem;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CouponApplicationTests {
 
     @Test

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.common.exception.AccessDeniedException;
 import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,9 @@ class CouponFacadeTest {
 
     @Mock
     private CouponManagementService couponManagementService;
+
+    @Mock
+    private CouponCachePort couponCachePort;
 
     @InjectMocks
     private CouponFacade couponFacade;

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
@@ -59,7 +59,7 @@ class CouponFacadeTest {
         UUID userId = UUID.randomUUID();
 
         //when, then
-        assertThatThrownBy(()->couponFacade.createCoupon(request, userType, userId))
+        assertThatThrownBy(() -> couponFacade.createCoupon(request, userType, userId))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("쿠폰 생성이 불가능합니다.");
     }
@@ -83,9 +83,34 @@ class CouponFacadeTest {
     @MethodSource("provideNonAdminRoles")
     void shouldThrowException_whenNonAdminTriesToDeactivateCoupon(String type, UserType userType) {
         //when, then
-        assertThatThrownBy(()->couponFacade.pauseCoupon(UUID.randomUUID(), UUID.randomUUID(), userType))
+        assertThatThrownBy(() -> couponFacade.pauseCoupon(UUID.randomUUID(), UUID.randomUUID(), userType))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("쿠폰 정지가 불가능합니다.");
+
+    }
+
+    @DisplayName("관리자가 쿠폰을 재시작하려하면 쿠폰 재시작을 시도한다.")
+    @Test
+    void shouldAttemptToReactivateCoupon_whenUserHasAdminRole() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        //when
+        couponFacade.resumeCoupon(couponId, userId, UserType.ADMIN);
+
+        //then
+        verify(couponManagementService).resume(couponId, userId);
+    }
+
+    @DisplayName("관리자가 아닌 유저가 쿠폰을 재시작하려 하면 예외가 발생한다.")
+    @ParameterizedTest(name = "[{index}] 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldThrowException_whenNonAdminUserTriesToReactivateCoupon(String type, UserType userType) {
+        //when, then
+        assertThatThrownBy(() -> couponFacade.resumeCoupon(UUID.randomUUID(), UUID.randomUUID(), userType))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("쿠폰 재시작이 불가능합니다.");
 
     }
 

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
@@ -25,6 +25,9 @@ class CouponFacadeTest {
     @Mock
     private CreateCouponService createCouponService;
 
+    @Mock
+    private CouponManagementService couponManagementService;
+
     @InjectMocks
     private CouponFacade couponFacade;
 
@@ -55,6 +58,31 @@ class CouponFacadeTest {
         assertThatThrownBy(()->couponFacade.createCoupon(request, userType, userId))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("쿠폰 생성이 불가능합니다.");
+    }
+
+    @DisplayName("관리자가 쿠폰을 정지하려하면 쿠폰 정지를 시도한다.")
+    @Test
+    void shouldAttemptToDeactivateCoupon_whenUserHasAdminRole() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        //when
+        couponFacade.pauseCoupon(couponId, userId, UserType.ADMIN);
+
+        //then
+        verify(couponManagementService).pause(couponId, userId);
+    }
+
+    @DisplayName("관리자가 아닌 유저가 쿠폰을 정지하려 하면 예외가 발생한다.")
+    @ParameterizedTest(name = "[{index}] 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldThrowException_whenNonAdminTriesToDeactivateCoupon(String type, UserType userType) {
+        //when, then
+        assertThatThrownBy(()->couponFacade.pauseCoupon(UUID.randomUUID(), UUID.randomUUID(), userType))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("쿠폰 정지가 불가능합니다.");
+
     }
 
     private static Stream<Arguments> provideNonAdminRoles() {

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
@@ -114,6 +114,31 @@ class CouponFacadeTest {
 
     }
 
+    @DisplayName("관리자가 쿠폰을 종료하려하면 쿠폰 종료를 시도한다.")
+    @Test
+    void shouldAttemptToExpireCoupon_whenUserHasAdminRole() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        //when
+        couponFacade.terminateCoupon(couponId, userId, UserType.ADMIN);
+
+        //then
+        verify(couponManagementService).terminate(couponId, userId);
+    }
+
+    @DisplayName("관리자가 아닌 유저가 쿠폰을 종료하려하면 예외가 발생한다.")
+    @ParameterizedTest(name = "[{index}] 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldThrowException_whenNonAdminUserTriesToExpireCoupon(String type, UserType userType) {
+        //when, then
+        assertThatThrownBy(() -> couponFacade.terminateCoupon(UUID.randomUUID(), UUID.randomUUID(), userType))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("쿠폰 종료가 불가능합니다.");
+
+    }
+
     private static Stream<Arguments> provideNonAdminRoles() {
         return Stream.of(
                 Arguments.of("레스토랑 소유자", UserType.RESTAURANT_OWNER),

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponFacadeTest.java
@@ -1,0 +1,67 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.common.exception.AccessDeniedException;
+import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CouponFacadeTest {
+
+    @Mock
+    private CreateCouponService createCouponService;
+
+    @InjectMocks
+    private CouponFacade couponFacade;
+
+    @DisplayName("관리자가 쿠폰 생성 요청시 쿠폰 생성을 시도한다.")
+    @Test
+    void shouldAttemptToCreateCoupon_whenUserIsAdmin() {
+        //given
+        CreateCouponApplicationRequest request = mock(CreateCouponApplicationRequest.class);
+        UserType userType = UserType.ADMIN;
+        UUID userId = UUID.randomUUID();
+
+        //when
+        couponFacade.createCoupon(request, userType, userId);
+
+        //then
+        verify(createCouponService).create(request, userId);
+    }
+
+    @DisplayName("관리자가 아닌 유저가 쿠폰 생성시 쿠폰 생성이 불가능하고, 예외가 발생한다.")
+    @ParameterizedTest(name = "[{index}] 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldThrowException_whenNonAdminTriesToCreateCoupon(String type, UserType userType) {
+        //given
+        CreateCouponApplicationRequest request = mock(CreateCouponApplicationRequest.class);
+        UUID userId = UUID.randomUUID();
+
+        //when, then
+        assertThatThrownBy(()->couponFacade.createCoupon(request, userType, userId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("쿠폰 생성이 불가능합니다.");
+    }
+
+    private static Stream<Arguments> provideNonAdminRoles() {
+        return Stream.of(
+                Arguments.of("레스토랑 소유자", UserType.RESTAURANT_OWNER),
+                Arguments.of("구매자", UserType.CUSTOMER)
+        );
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
@@ -1,0 +1,63 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CouponManagementServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @InjectMocks
+    private CouponManagementService couponManagementService;
+
+    @DisplayName("쿠폰이 존재하면 쿠폰을 정지할 수 있다.")
+    @Test
+    void shouldDeactivateCoupon_whenCouponExists() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+
+        //when
+        couponManagementService.pause(couponId, userId);
+
+        //then
+        verify(coupon, times(1)).pause();
+    }
+
+    @DisplayName("쿠폰이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenCouponDoesNotExist() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(()->couponManagementService.pause(couponId, userId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
@@ -94,7 +94,7 @@ class CouponManagementServiceTest {
         verify(couponCachePort, times(1)).enableCoupon(eq(couponId), anyLong(), any(LocalDateTime.class));
     }
 
-    @DisplayName("쿠폰이 존재하지 않으면 쿠폰 재시작시 예외가 발생한다.")
+    @DisplayName("쿠폰이 존재하지 않으면 쿠폰 재시작 시 예외가 발생한다.")
     @Test
     void shouldThrowException_whenTryingToReactivateNonExistentCoupon() {
         //given
@@ -109,6 +109,43 @@ class CouponManagementServiceTest {
                 .hasMessage("쿠폰이 존재하지 않습니다.");
 
         verify(couponCachePort, never()).enableCoupon(eq(couponId), anyLong(), any(LocalDateTime.class));
+    }
+
+    @DisplayName("쿠폰이 존재하면 쿠폰을 종료할 수 있다.")
+    @Test
+    void shouldExpireCoupon_whenCouponExists() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+
+        //when
+        couponManagementService.terminate(couponId, userId);
+
+        //then
+        verify(coupon, times(1)).terminate();
+        verify(couponCachePort, times(1)).setExpireIssuedUserKey(couponId);
+    }
+
+    @DisplayName("쿠폰이 존재하지 않으면 쿠폰 종료시 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenExpiringNonExistentCoupon() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> couponManagementService.terminate(couponId, userId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
+
+        verify(couponCachePort, never()).deleteCouponStock(couponId);
+        verify(couponCachePort, never()).setExpireIssuedUserKey(couponId);
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CouponManagementServiceTest.java
@@ -1,14 +1,20 @@
 package com.orderingsystem.coupon.application;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +29,9 @@ class CouponManagementServiceTest {
 
     @Mock
     private CouponRepository couponRepository;
+
+    @Mock
+    private CouponCachePort couponCachePort;
 
     @InjectMocks
     private CouponManagementService couponManagementService;
@@ -43,6 +52,7 @@ class CouponManagementServiceTest {
 
         //then
         verify(coupon, times(1)).pause();
+        verify(couponCachePort, times(1)).deleteCouponStock(couponId);
     }
 
     @DisplayName("쿠폰이 존재하지 않으면 예외가 발생한다.")
@@ -55,9 +65,50 @@ class CouponManagementServiceTest {
         given(couponRepository.findById(couponId)).willReturn(Optional.empty());
 
         //when, then
-        assertThatThrownBy(()->couponManagementService.pause(couponId, userId))
+        assertThatThrownBy(() -> couponManagementService.pause(couponId, userId))
                 .isInstanceOf(CouponNotFoundException.class)
                 .hasMessage("쿠폰이 존재하지 않습니다.");
+
+        verify(couponCachePort, never()).deleteCouponStock(couponId);
+    }
+
+    @DisplayName("쿠폰이 존재하면 쿠폰을 재시작할 수 있다.")
+    @Test
+    void shouldReactivateCoupon_whenCouponExists() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+        given(coupon.getIssueLimit()).willReturn(100L);
+        given(coupon.getIssuedCount()).willReturn(10L);
+        given(coupon.getValidUntil()).willReturn(LocalDateTime.now());
+
+        //when
+        couponManagementService.resume(couponId, userId);
+
+        //then
+        verify(coupon, times(1)).resume();
+        verify(couponCachePort, times(1)).enableCoupon(eq(couponId), anyLong(), any(LocalDateTime.class));
+    }
+
+    @DisplayName("쿠폰이 존재하지 않으면 쿠폰 재시작시 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenTryingToReactivateNonExistentCoupon() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> couponManagementService.resume(couponId, userId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
+
+        verify(couponCachePort, never()).enableCoupon(eq(couponId), anyLong(), any(LocalDateTime.class));
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
@@ -1,0 +1,62 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateCouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @InjectMocks
+    private CreateCouponService createCouponService;
+
+    @DisplayName("쿠폰 생성 요청이 들어오면 쿠폰을 생성하고 DB에 저장한다.")
+    @Test
+    void shouldCreateAndPersistCoupon_whenRequestIsValid() {
+        //given
+        CreateCouponApplicationRequest request = CreateCouponApplicationRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025,12,4,0,0))
+                .validUntil(LocalDateTime.of(2025,12,20,0,0))
+                .issueLimit(10_000L)
+                .build();
+        UUID userId = UUID.randomUUID();
+
+        // when
+        createCouponService.create(request, userId);
+
+        // then
+        ArgumentCaptor<Coupon> captor = ArgumentCaptor.forClass(Coupon.class);
+        verify(couponRepository).save(captor.capture());
+
+        Coupon saved = captor.getValue();
+        assertThat(saved.getDiscountType()).isEqualTo(DiscountType.FIXED_AMOUNT);
+        assertThat(saved.getAmountOff()).isEqualByComparingTo("2000");
+        assertThat(saved.getPercentOff()).isNull();
+        assertThat(saved.getMaxDiscountAmount()).isNull();
+        assertThat(saved.getMinDiscountAmount()).isEqualByComparingTo("10000");
+        assertThat(saved.getValidFrom()).isEqualTo(LocalDateTime.of(2025,12,4,0,0));
+        assertThat(saved.getValidUntil()).isEqualTo(LocalDateTime.of(2025,12,20,0,0));
+        assertThat(saved.getIssueLimit()).isEqualTo(10_000L);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
@@ -19,7 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class CreateFindCouponServiceTest {
+class CreateCouponServiceTest {
 
     @Mock
     private CouponRepository couponRepository;

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CreateCouponServiceTest.java
@@ -1,9 +1,12 @@
 package com.orderingsystem.coupon.application;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.orderingsystem.coupon.application.dto.request.CreateCouponApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponSchedulerPort;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.DiscountType;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
@@ -24,6 +27,9 @@ class CreateCouponServiceTest {
     @Mock
     private CouponRepository couponRepository;
 
+    @Mock
+    private CouponSchedulerPort couponSchedulerPort;
+
     @InjectMocks
     private CreateCouponService createCouponService;
 
@@ -35,11 +41,15 @@ class CreateCouponServiceTest {
                 .discountType(DiscountType.FIXED_AMOUNT)
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
-                .validFrom(LocalDateTime.of(2025,12,4,0,0))
-                .validUntil(LocalDateTime.of(2025,12,20,0,0))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
                 .issueLimit(10_000L)
                 .build();
+
         UUID userId = UUID.randomUUID();
+
+        given(couponRepository.save(any(Coupon.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         createCouponService.create(request, userId);
@@ -54,9 +64,12 @@ class CreateCouponServiceTest {
         assertThat(saved.getPercentOff()).isNull();
         assertThat(saved.getMaxDiscountAmount()).isNull();
         assertThat(saved.getMinDiscountAmount()).isEqualByComparingTo("10000");
-        assertThat(saved.getValidFrom()).isEqualTo(LocalDateTime.of(2025,12,4,0,0));
-        assertThat(saved.getValidUntil()).isEqualTo(LocalDateTime.of(2025,12,20,0,0));
+        assertThat(saved.getValidFrom()).isEqualTo(LocalDateTime.of(2025, 12, 4, 0, 0));
+        assertThat(saved.getValidUntil()).isEqualTo(LocalDateTime.of(2025, 12, 20, 0, 0));
         assertThat(saved.getIssueLimit()).isEqualTo(10_000L);
+
+        verify(couponSchedulerPort).scheduleCouponStart(saved.getCouponId(), request.getIssueLimit(),
+                request.getValidFrom(), request.getValidUntil());
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/CreateFindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/CreateFindCouponServiceTest.java
@@ -19,7 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class CreateCouponServiceTest {
+class CreateFindCouponServiceTest {
 
     @Mock
     private CouponRepository couponRepository;

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
+import com.orderingsystem.common.exception.AccessDeniedException;
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
@@ -245,6 +247,109 @@ class FindCouponServiceTest {
 
         //when, then
         assertThatThrownBy(() -> findCouponService.getCoupon(UUID.randomUUID(), couponId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
+    }
+
+    @DisplayName("발급한 쿠폰 id로 발급한 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveIssuedCouponById_whenUserIsOwner() {
+        //given
+        UUID userId = UUID.randomUUID();
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .issuedCount(10L)
+                .build();
+
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .id(10L)
+                .userId(userId)
+                .couponId(coupon.getCouponId())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.now().withNano(0))
+                .expiredAt(LocalDateTime.now().plusDays(1).withNano(0))
+                .build();
+
+        given(couponRepository.findById(coupon.getCouponId())).willReturn(Optional.of(coupon));
+        given(issuedCouponRepository.findById(issuedCoupon.getId())).willReturn(Optional.of(issuedCoupon));
+
+        //when
+        IssuedCouponResponse response = findCouponService.getIssuedCoupon(userId, issuedCoupon.getId());
+
+        //then
+        assertThat(response.getCouponId()).isEqualTo(coupon.getCouponId());
+        assertThat(response.getCouponName()).isEqualTo(coupon.getName());
+        assertThat(response.getIssuedCouponId()).isEqualTo(issuedCoupon.getId());
+        assertThat(response.getIssuedCouponStatus()).isEqualTo(issuedCoupon.getStatus());
+        assertThat(response.getIssuedAt()).isEqualTo(issuedCoupon.getIssuedAt());
+        assertThat(response.getUsedAt()).isEqualTo(issuedCoupon.getUsedAt());
+        assertThat(response.getExpiredAt()).isEqualTo(issuedCoupon.getExpiredAt());
+        assertThat(response.getDiscountType()).isEqualTo(coupon.getDiscountType());
+        assertThat(response.getAmountOff()).isEqualTo(coupon.getAmountOff());
+        assertThat(response.getPercentOff()).isEqualTo(coupon.getPercentOff());
+        assertThat(response.getMaxDiscountAmount()).isEqualTo(coupon.getMaxDiscountAmount());
+        assertThat(response.getMinOrderAmount()).isEqualTo(coupon.getMinDiscountAmount());
+    }
+
+    @DisplayName("발급한 쿠폰 정보 조회시 발급한 쿠폰 정보가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenIssuedCouponNotFound() {
+        //given
+        UUID userId = UUID.randomUUID();
+        Long issuedCouponId = 100L;
+
+        given(issuedCouponRepository.findById(issuedCouponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> findCouponService.getIssuedCoupon(userId, issuedCouponId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("발급한 쿠폰 정보가 존재하지 않습니다.");
+    }
+
+    @DisplayName("발급한 쿠폰 정보 조회시 유저가 발급하지 않은 쿠폰 조회를 요청한 경우 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenUserIsNotOwnerOfIssuedCoupon() {
+        //given
+        UUID userId = UUID.randomUUID();
+        Long issuedCouponId = 100L;
+
+        IssuedCoupon issuedCoupon = mock(IssuedCoupon.class);
+
+        given(issuedCouponRepository.findById(issuedCouponId)).willReturn(Optional.of(issuedCoupon));
+        given(issuedCoupon.getId()).willReturn(100L);
+        given(issuedCoupon.getUserId()).willReturn(UUID.randomUUID());
+
+        //when, then
+        assertThatThrownBy(() -> findCouponService.getIssuedCoupon(userId, issuedCouponId))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("발급한 쿠폰 정보를 조회할 권한이 없습니다.");
+    }
+
+    @DisplayName("발급한 쿠폰 정보 조회시 쿠폰 정보가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenCouponNotFoundFromIssuedCoupon() {
+        //given
+        UUID userId = UUID.randomUUID();
+        UUID couponId = UUID.randomUUID();
+        Long issuedCouponId = 100L;
+
+        IssuedCoupon issuedCoupon = mock(IssuedCoupon.class);
+
+        given(issuedCouponRepository.findById(issuedCouponId)).willReturn(Optional.of(issuedCoupon));
+        given(issuedCoupon.getUserId()).willReturn(userId);
+        given(issuedCoupon.getCouponId()).willReturn(couponId);
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> findCouponService.getIssuedCoupon(userId, issuedCouponId))
                 .isInstanceOf(CouponNotFoundException.class)
                 .hasMessage("쿠폰이 존재하지 않습니다.");
     }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -1,0 +1,114 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.BDDMockito.given;
+
+import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FindCouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private IssuedCouponRepository issuedCouponRepository;
+
+    @InjectMocks
+    private FindCouponService findCouponService;
+
+    @DisplayName("해당 사용자가 발급한 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveIssuedCouponsByUserId() {
+        //given
+        UUID userId = UUID.randomUUID();
+        List<IssuedCouponStatus> couponStatus = List.of(IssuedCouponStatus.ISSUED);
+
+        UUID couponId1 = UUID.randomUUID();
+        UUID couponId2 = UUID.randomUUID();
+
+        IssuedCoupon issuedCoupon1 = IssuedCoupon.builder()
+                .id(1L)
+                .userId(userId)
+                .couponId(couponId1)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                .build();
+
+        IssuedCoupon issuedCoupon2 = IssuedCoupon.builder()
+                .id(2L)
+                .userId(userId)
+                .couponId(couponId2)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                .build();
+
+        List<IssuedCoupon> issuedCoupons = List.of(issuedCoupon1, issuedCoupon2);
+        given(issuedCouponRepository.findByUserIdAndStatusIn(userId, couponStatus)).willReturn(issuedCoupons);
+
+        Coupon coupon1 = Coupon.builder()
+                .couponId(couponId1)
+                .name("쿠폰1")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        Coupon coupon2 = Coupon.builder()
+                .couponId(couponId2)
+                .name("쿠폰2")
+                .discountType(DiscountType.PERCENTAGE)
+                .status(CouponStatus.ACTIVE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(3000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        given(couponRepository.findAllByCouponIdIn(List.of(couponId1, couponId2))).willReturn(
+                List.of(coupon1, coupon2));
+
+        //when
+        List<IssuedCouponResponse> responses = findCouponService.getIssuedCoupons(userId, couponStatus);
+
+        //then
+        assertThat(responses).hasSize(2)
+                .extracting("couponId", "couponName", "issuedCouponId", "issuedCouponStatus", "issuedAt", "usedAt",
+                        "expiredAt", "discountType", "amountOff", "percentOff", "maxDiscountAmount", "minOrderAmount")
+                .containsExactlyInAnyOrder(
+                        tuple(coupon1.getCouponId(), coupon1.getName(), issuedCoupon1.getId(),
+                                issuedCoupon1.getStatus(), issuedCoupon1.getIssuedAt(), issuedCoupon1.getUsedAt(),
+                                issuedCoupon1.getExpiredAt(), coupon1.getDiscountType(), coupon1.getAmountOff(),
+                                coupon1.getPercentOff(), coupon1.getMaxDiscountAmount(), coupon1.getMinDiscountAmount()),
+                        tuple(coupon2.getCouponId(), coupon2.getName(), issuedCoupon2.getId(),
+                                issuedCoupon2.getStatus(), issuedCoupon2.getIssuedAt(), issuedCoupon2.getUsedAt(),
+                                issuedCoupon2.getExpiredAt(), coupon2.getDiscountType(), coupon2.getAmountOff(),
+                                coupon2.getPercentOff(), coupon2.getMaxDiscountAmount(), coupon2.getMinDiscountAmount())
+                );
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -52,12 +53,14 @@ class FindCouponServiceTest {
         UUID couponId1 = UUID.randomUUID();
         UUID couponId2 = UUID.randomUUID();
 
+        LocalDateTime dateTime = LocalDateTime.now().plusDays(10);
+
         IssuedCoupon issuedCoupon1 = IssuedCoupon.builder()
                 .id(1L)
                 .userId(userId)
                 .couponId(couponId1)
                 .status(IssuedCouponStatus.ISSUED)
-                .issuedAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                .issuedAt(dateTime)
                 .build();
 
         IssuedCoupon issuedCoupon2 = IssuedCoupon.builder()
@@ -65,11 +68,11 @@ class FindCouponServiceTest {
                 .userId(userId)
                 .couponId(couponId2)
                 .status(IssuedCouponStatus.ISSUED)
-                .issuedAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                .issuedAt(dateTime)
                 .build();
 
         List<IssuedCoupon> issuedCoupons = List.of(issuedCoupon1, issuedCoupon2);
-        given(issuedCouponRepository.findByUserIdAndStatusIn(userId, couponStatus)).willReturn(issuedCoupons);
+        given(issuedCouponRepository.findByUserIdAndStatusIn(eq(userId), anyCollection())).willReturn(issuedCoupons);
 
         Coupon coupon1 = Coupon.builder()
                 .couponId(couponId1)

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -1,11 +1,13 @@
 package com.orderingsystem.coupon.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.BDDMockito.given;
 
 import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.DiscountType;
@@ -16,6 +18,7 @@ import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -192,6 +195,58 @@ class FindCouponServiceTest {
                                 coupon2.getIssuedCount()
                         )
                 );
+    }
+
+    @DisplayName("쿠폰 id로 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveCouponByCouponCode_whenValidCodeProvided() {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .issuedCount(10L)
+                .build();
+
+        given(couponRepository.findById(coupon.getCouponId())).willReturn(Optional.of(coupon));
+
+        //when
+        CouponResponse response = findCouponService.getCoupon(UUID.randomUUID(), coupon.getCouponId());
+
+        //then
+        assertThat(response.getCouponId()).isEqualTo(coupon.getCouponId());
+        assertThat(response.getCouponName()).isEqualTo(coupon.getName());
+        assertThat(response.getDiscountType()).isEqualTo(coupon.getDiscountType());
+        assertThat(response.getCouponStatus()).isEqualTo(coupon.getStatus());
+        assertThat(response.getAmountOff()).isEqualTo(coupon.getAmountOff());
+        assertThat(response.getPercentOff()).isEqualTo(coupon.getPercentOff());
+        assertThat(response.getMaxDiscountAmount()).isEqualTo(coupon.getMaxDiscountAmount());
+        assertThat(response.getMinDiscountAmount()).isEqualTo(coupon.getMinDiscountAmount());
+        assertThat(response.getValidFrom()).isEqualTo(coupon.getValidFrom());
+        assertThat(response.getValidUntil()).isEqualTo(coupon.getValidUntil());
+        assertThat(response.getValidDays()).isEqualTo(coupon.getValidDays());
+        assertThat(response.getIssueLimit()).isEqualTo(coupon.getIssueLimit());
+        assertThat(response.getIssuedCount()).isEqualTo(coupon.getIssuedCount());
+    }
+
+    @DisplayName("쿠폰 id로 쿠폰 조회시 해당 쿠폰이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenCouponIdDoesNotExist() {
+        //given
+        UUID couponId = UUID.randomUUID();
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> findCouponService.getCoupon(UUID.randomUUID(), couponId))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -3,6 +3,7 @@ package com.orderingsystem.coupon.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -153,7 +154,7 @@ class FindCouponServiceTest {
                 .issueLimit(1000L)
                 .build();
 
-        given(couponRepository.findAllByStatusIn(couponStatus)).willReturn(List.of(coupon1, coupon2));
+        given(couponRepository.findAllByStatusIn(anyCollection())).willReturn(List.of(coupon1, coupon2));
 
         //when
         List<CouponResponse> responses = findCouponService.getCoupons(userId, couponStatus);

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/FindCouponServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.BDDMockito.given;
 
+import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
@@ -103,11 +104,93 @@ class FindCouponServiceTest {
                         tuple(coupon1.getCouponId(), coupon1.getName(), issuedCoupon1.getId(),
                                 issuedCoupon1.getStatus(), issuedCoupon1.getIssuedAt(), issuedCoupon1.getUsedAt(),
                                 issuedCoupon1.getExpiredAt(), coupon1.getDiscountType(), coupon1.getAmountOff(),
-                                coupon1.getPercentOff(), coupon1.getMaxDiscountAmount(), coupon1.getMinDiscountAmount()),
+                                coupon1.getPercentOff(), coupon1.getMaxDiscountAmount(),
+                                coupon1.getMinDiscountAmount()),
                         tuple(coupon2.getCouponId(), coupon2.getName(), issuedCoupon2.getId(),
                                 issuedCoupon2.getStatus(), issuedCoupon2.getIssuedAt(), issuedCoupon2.getUsedAt(),
                                 issuedCoupon2.getExpiredAt(), coupon2.getDiscountType(), coupon2.getAmountOff(),
                                 coupon2.getPercentOff(), coupon2.getMaxDiscountAmount(), coupon2.getMinDiscountAmount())
+                );
+    }
+
+    @DisplayName("쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveCoupons_whenUserIsValid() {
+        //given
+        UUID userId = UUID.randomUUID();
+        List<CouponStatus> couponStatus = List.of(CouponStatus.ACTIVE);
+
+        UUID couponId1 = UUID.randomUUID();
+        UUID couponId2 = UUID.randomUUID();
+
+        Coupon coupon1 = Coupon.builder()
+                .couponId(couponId1)
+                .name("쿠폰1")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        Coupon coupon2 = Coupon.builder()
+                .couponId(couponId2)
+                .name("쿠폰2")
+                .discountType(DiscountType.PERCENTAGE)
+                .status(CouponStatus.ACTIVE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(3000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        given(couponRepository.findAllByStatusIn(couponStatus)).willReturn(List.of(coupon1, coupon2));
+
+        //when
+        List<CouponResponse> responses = findCouponService.getCoupons(userId, couponStatus);
+
+        //then
+        assertThat(responses).hasSize(2)
+                .extracting(
+                        "couponId", "couponName", "discountType", "couponStatus", "amountOff", "percentOff",
+                        "maxDiscountAmount", "minDiscountAmount", "validFrom", "validUntil", "validDays", "issueLimit",
+                        "issuedCount"
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(
+                                coupon1.getCouponId(),
+                                coupon1.getName(),
+                                coupon1.getDiscountType(),
+                                coupon1.getStatus(),
+                                coupon1.getAmountOff(),
+                                coupon1.getPercentOff(),
+                                coupon1.getMaxDiscountAmount(),
+                                coupon1.getMinDiscountAmount(),
+                                coupon1.getValidFrom(),
+                                coupon1.getValidUntil(),
+                                coupon1.getValidDays(),
+                                coupon1.getIssueLimit(),
+                                coupon1.getIssuedCount()
+                        ),
+                        tuple(
+                                coupon2.getCouponId(),
+                                coupon2.getName(),
+                                coupon2.getDiscountType(),
+                                coupon2.getStatus(),
+                                coupon2.getAmountOff(),
+                                coupon2.getPercentOff(),
+                                coupon2.getMaxDiscountAmount(),
+                                coupon2.getMinDiscountAmount(),
+                                coupon2.getValidFrom(),
+                                coupon2.getValidUntil(),
+                                coupon2.getValidDays(),
+                                coupon2.getIssueLimit(),
+                                coupon2.getIssuedCount()
+                        )
                 );
     }
 

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceConcurrencyTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceConcurrencyTest.java
@@ -1,0 +1,141 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
+import com.orderingsystem.coupon.infra.redis.RedisCouponRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class IssueCouponServiceConcurrencyTest {
+
+    @Autowired
+    private IssueCouponService issueCouponService;
+
+    @Autowired
+    private RedisCouponRepository redisCouponRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @MockitoBean
+    private CouponIssueMessagePublisher couponIssueMessagePublisher;
+
+    @DisplayName("재고가 100개일 때 1000명이 동시에 요청하면 정확히 100개만 발급되어야 한다.")
+    @Test
+    void shouldIssueExactly100Coupons_when1000ConcurrentRequestsAndStockIs100() throws InterruptedException {
+        //given
+        int threadCount = 1000;
+        Long issueLimit = 100L;
+        UUID couponId = UUID.randomUUID();
+
+        redisCouponRepository.enableCoupon(couponId, issueLimit, LocalDateTime.now().plusDays(1));
+
+        doNothing().when(couponIssueMessagePublisher).publish(any());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    issueCouponService.requestCouponIssuance(couponId, UUID.randomUUID(), LocalDateTime.now());
+                    successCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        //then
+        assertThat(successCount.get()).isEqualTo(issueLimit.intValue());
+        assertThat(failCount.get()).isEqualTo(threadCount - issueLimit);
+
+        long currentStock = redisCouponRepository.currentStock(couponId);
+        assertThat(currentStock).isEqualTo(0L);
+    }
+
+    @DisplayName("같은 유저가 동시에 여러 번 요청해도 쿠폰은 한 번만 발급되어야 한다.")
+    @Test
+    void shouldIssueCouponOnlyOnce_whenSameUserRequestsConcurrently() throws InterruptedException {
+        //given
+        int threadCount = 5;
+        Long issueLimit = 10L;
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        redisCouponRepository.enableCoupon(couponId, issueLimit, LocalDateTime.now().plusDays(1L));
+
+        doNothing().when(couponIssueMessagePublisher).publish(any());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    issueCouponService.requestCouponIssuance(couponId, userId, LocalDateTime.now());
+                    successCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        //then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        long currentStock = redisCouponRepository.currentStock(couponId);
+        assertThat(currentStock).isEqualTo(issueLimit - 1);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
@@ -1,0 +1,244 @@
+package com.orderingsystem.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.orderingsystem.coupon.application.dto.request.CouponIssueApplicationRequest;
+import com.orderingsystem.coupon.application.port.out.CouponCachePort;
+import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
+import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
+import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IssueCouponServiceTest {
+
+    @Mock
+    private CouponCachePort couponCachePort;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private IssuedCouponRepository issuedCouponRepository;
+
+    @Mock
+    private CouponIssueMessagePublisher couponIssueMessagePublisher;
+
+    @InjectMocks
+    private IssueCouponService issueCouponService;
+
+    @DisplayName("재고가 있고 최초 발급이면 이벤트를 발행한다.")
+    @Test
+    void shouldPublishEvent_whenFirstIssuanceAndStockAvailable() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(true);
+        given(couponCachePort.addIssuedUser(couponId, userId)).willReturn(true);
+        given(couponCachePort.decreaseStock(couponId)).willReturn(100L);
+
+        //when
+        issueCouponService.requestCouponIssuance(couponId, userId, now);
+
+        //then
+        ArgumentCaptor<CouponIssuedEvent> captor = ArgumentCaptor.forClass(CouponIssuedEvent.class);
+        verify(couponIssueMessagePublisher).publish(captor.capture());
+
+        CouponIssuedEvent event = captor.getValue();
+        assertThat(event.getCouponId()).isEqualTo(couponId);
+        assertThat(event.getUserId()).isEqualTo(userId);
+        assertThat(event.getCreatedAt()).isEqualTo(now);
+
+        verify(couponCachePort, never()).increaseStock(any());
+        verify(couponCachePort, never()).removeIssuedUser(any(), any());
+    }
+
+    @DisplayName("쿠폰이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenCouponDoesNotExist() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(false);
+
+        //when, then
+        assertThatThrownBy(() -> issueCouponService.requestCouponIssuance(couponId, userId, now))
+                .isInstanceOf(CouponNotFoundException.class)
+                .hasMessage("존재하지 않는 쿠폰입니다.");
+
+        verify(couponCachePort, never()).addIssuedUser(any(), any());
+        verify(couponCachePort, never()).decreaseStock(any());
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+    @DisplayName("이미 해당 쿠폰을 발급한 사용자가 쿠폰 발급을 요청하면 예외가 발생한다.")
+    @Test
+    void shouldThrowException_whenCouponAlreadyIssued() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(true);
+        given(couponCachePort.addIssuedUser(couponId, userId)).willReturn(false);
+
+        //when, then
+        assertThatThrownBy(() -> issueCouponService.requestCouponIssuance(couponId, userId, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 쿠폰이 발급되었습니다.");
+
+        verify(couponCachePort, never()).decreaseStock(any());
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+    @DisplayName("재고 차감 결과가 음수라면 예외가 발생하고 롤백을 진행한다.")
+    @Test
+    void shouldRollback_whenStockDeductionResultIsNegative() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(true);
+        given(couponCachePort.addIssuedUser(couponId, userId)).willReturn(true);
+        given(couponCachePort.decreaseStock(couponId)).willReturn(-1L);
+
+        //when, then
+        assertThatThrownBy(() -> issueCouponService.requestCouponIssuance(couponId, userId, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰이 마감되었습니다.");
+
+        verify(couponCachePort).increaseStock(couponId);
+        verify(couponCachePort).removeIssuedUser(couponId, userId);
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+    @DisplayName("재고 차감 결과가 null이면 예외가 발생하고 롤백을 진행한다.")
+    @Test
+    void shouldRollback_whenStockDeductionResultIsNull() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(true);
+        given(couponCachePort.addIssuedUser(couponId, userId)).willReturn(true);
+        given(couponCachePort.decreaseStock(couponId)).willReturn(null);
+
+        //when, then
+        assertThatThrownBy(() -> issueCouponService.requestCouponIssuance(couponId, userId, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰이 마감되었습니다.");
+
+        verify(couponCachePort).increaseStock(couponId);
+        verify(couponCachePort).removeIssuedUser(couponId, userId);
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+    @DisplayName("publish 중 예외가 발생하면 예외가 발생하고 롤백을 진행한다.")
+    @Test
+    void shouldRollback_whenPublishingFailsDuringCouponIssue() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        given(couponCachePort.exists(couponId)).willReturn(true);
+        given(couponCachePort.addIssuedUser(couponId, userId)).willReturn(true);
+        given(couponCachePort.decreaseStock(couponId)).willReturn(1000L);
+
+        doThrow(new RuntimeException("publish failed"))
+                .when(couponIssueMessagePublisher).publish(any(CouponIssuedEvent.class));
+
+        //when
+        assertThatThrownBy(() -> issueCouponService.requestCouponIssuance(couponId, userId, now))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("쿠폰 발급 중 오류 발생");
+
+        //then
+        verify(couponCachePort).increaseStock(couponId);
+        verify(couponCachePort).removeIssuedUser(couponId, userId);
+    }
+
+    @DisplayName("쿠폰 저장 중 요청이 비어있으면 아무 것도 하지 않는다.")
+    @Test
+    void shouldDoNothing_whenIssuedCouponRequestIsEmpty() {
+        //when
+        issueCouponService.saveIssuedCoupon(Collections.emptyList());
+
+        //then
+        verifyNoInteractions(issuedCouponRepository, couponRepository);
+    }
+
+    @DisplayName("쿠폰 저장 요청이 들어오면 쿠폰 발급 정보를 저장하고 쿠폰별 집계 수만큼 쿠폰 발급 개수를 증가시킨다.")
+    @Test
+    void shouldPersistIssuedCouponsAndIncrementCountByAggregate() {
+        //given
+        UUID coupon1 = UUID.randomUUID();
+        UUID coupon2 = UUID.randomUUID();
+
+        CouponIssueApplicationRequest r1 = mock(CouponIssueApplicationRequest.class);
+        CouponIssueApplicationRequest r2 = mock(CouponIssueApplicationRequest.class);
+        CouponIssueApplicationRequest r3 = mock(CouponIssueApplicationRequest.class);
+
+        given(r1.getCouponId()).willReturn(coupon1);
+        given(r2.getCouponId()).willReturn(coupon1);
+        given(r3.getCouponId()).willReturn(coupon2);
+
+        given(r1.getUserId()).willReturn(UUID.randomUUID());
+        given(r2.getUserId()).willReturn(UUID.randomUUID());
+        given(r3.getUserId()).willReturn(UUID.randomUUID());
+
+        given(r1.getIssuedAt()).willReturn(LocalDateTime.now());
+        given(r2.getIssuedAt()).willReturn(LocalDateTime.now());
+        given(r3.getIssuedAt()).willReturn(LocalDateTime.now());
+
+        given(r1.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
+        given(r2.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
+        given(r3.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
+
+        List<CouponIssueApplicationRequest> requests = Arrays.asList(r1, r2, r3);
+
+        ArgumentCaptor<List<IssuedCoupon>> saveCap = ArgumentCaptor.forClass(List.class);
+
+        //when
+        issueCouponService.saveIssuedCoupon(requests);
+
+        //then
+        verify(issuedCouponRepository).saveAll(saveCap.capture());
+        List<IssuedCoupon> saved = saveCap.getValue();
+        assertThat(saved).hasSize(3);
+
+        verify(couponRepository).increaseIssuedCount(coupon1, 2L);
+        verify(couponRepository).increaseIssuedCount(coupon2, 1L);
+        verifyNoMoreInteractions(couponRepository);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
@@ -9,13 +9,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.orderingsystem.coupon.application.dto.request.CouponIssueApplicationRequest;
 import com.orderingsystem.coupon.application.port.out.CouponCachePort;
 import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
 import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
 import com.orderingsystem.coupon.domain.exception.CouponNotFoundException;
+import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.IssuedCoupon;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
@@ -197,35 +197,43 @@ class IssueCouponServiceTest {
         verifyNoInteractions(issuedCouponRepository, couponRepository);
     }
 
-    @DisplayName("쿠폰 저장 요청이 들어오면 쿠폰 발급 정보를 저장하고 쿠폰별 집계 수만큼 쿠폰 발급 개수를 증가시킨다.")
+    @DisplayName("쿠폰 저장 요청이 들어오면 쿠폰 발급 정보를 저장하고, 유효기간(expiredAt)이 정책에 맞게 계산되었는지 검증한다.")
     @Test
-    void shouldPersistIssuedCouponsAndIncrementCountByAggregate() {
+    void shouldPersistIssuedCouponsAndVerifyExpirationDate() {
         //given
-        UUID coupon1 = UUID.randomUUID();
-        UUID coupon2 = UUID.randomUUID();
+        UUID couponId1 = UUID.randomUUID();
+        UUID couponId2 = UUID.randomUUID();
+
+        LocalDateTime fixedIssuedAt = LocalDateTime.of(2025, 1, 1, 12, 0, 0);
+
+        Coupon mockCoupon1 = mock(Coupon.class);
+        given(mockCoupon1.getCouponId()).willReturn(couponId1);
+        given(mockCoupon1.getValidDays()).willReturn(30);
+
+        Coupon mockCoupon2 = mock(Coupon.class);
+        given(mockCoupon2.getCouponId()).willReturn(couponId2);
+        given(mockCoupon2.getValidDays()).willReturn(7);
+
+        given(couponRepository.findAllByCouponIdIn(any()))
+                .willReturn(List.of(mockCoupon1, mockCoupon2));
 
         CouponIssueApplicationRequest r1 = mock(CouponIssueApplicationRequest.class);
         CouponIssueApplicationRequest r2 = mock(CouponIssueApplicationRequest.class);
         CouponIssueApplicationRequest r3 = mock(CouponIssueApplicationRequest.class);
 
-        given(r1.getCouponId()).willReturn(coupon1);
-        given(r2.getCouponId()).willReturn(coupon1);
-        given(r3.getCouponId()).willReturn(coupon2);
-
+        given(r1.getCouponId()).willReturn(couponId1);
         given(r1.getUserId()).willReturn(UUID.randomUUID());
+        given(r1.getIssuedAt()).willReturn(fixedIssuedAt);
+
+        given(r2.getCouponId()).willReturn(couponId1);
         given(r2.getUserId()).willReturn(UUID.randomUUID());
+        given(r2.getIssuedAt()).willReturn(fixedIssuedAt);
+
+        given(r3.getCouponId()).willReturn(couponId2);
         given(r3.getUserId()).willReturn(UUID.randomUUID());
-
-        given(r1.getIssuedAt()).willReturn(LocalDateTime.now());
-        given(r2.getIssuedAt()).willReturn(LocalDateTime.now());
-        given(r3.getIssuedAt()).willReturn(LocalDateTime.now());
-
-        given(r1.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
-        given(r2.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
-        given(r3.getExpiredAt()).willReturn(LocalDateTime.now().plusDays(30));
+        given(r3.getIssuedAt()).willReturn(fixedIssuedAt);
 
         List<CouponIssueApplicationRequest> requests = Arrays.asList(r1, r2, r3);
-
         ArgumentCaptor<List<IssuedCoupon>> saveCap = ArgumentCaptor.forClass(List.class);
 
         //when
@@ -233,12 +241,25 @@ class IssueCouponServiceTest {
 
         //then
         verify(issuedCouponRepository).saveAll(saveCap.capture());
-        List<IssuedCoupon> saved = saveCap.getValue();
-        assertThat(saved).hasSize(3);
+        List<IssuedCoupon> savedCoupons = saveCap.getValue();
 
-        verify(couponRepository).increaseIssuedCount(coupon1, 2L);
-        verify(couponRepository).increaseIssuedCount(coupon2, 1L);
-        verifyNoMoreInteractions(couponRepository);
+        assertThat(savedCoupons).hasSize(3);
+
+        IssuedCoupon saved1 = savedCoupons.get(0);
+        assertThat(saved1.getCouponId()).isEqualTo(couponId1);
+        assertThat(saved1.getIssuedAt()).isEqualTo(fixedIssuedAt);
+        assertThat(saved1.getExpiredAt()).isEqualTo(fixedIssuedAt.plusDays(30));
+
+        IssuedCoupon saved2 = savedCoupons.get(1);
+        assertThat(saved2.getCouponId()).isEqualTo(couponId1);
+        assertThat(saved2.getExpiredAt()).isEqualTo(fixedIssuedAt.plusDays(30));
+
+        IssuedCoupon saved3 = savedCoupons.get(2);
+        assertThat(saved3.getCouponId()).isEqualTo(couponId2);
+        assertThat(saved3.getExpiredAt()).isEqualTo(fixedIssuedAt.plusDays(7));
+
+        verify(couponRepository).increaseIssuedCount(couponId1, 2L);
+        verify(couponRepository).increaseIssuedCount(couponId2, 1L);
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/IssueCouponServiceTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class IssueFindCouponServiceTest {
+class IssueCouponServiceTest {
 
     @Mock
     private CouponCachePort couponCachePort;

--- a/coupon/src/test/java/com/orderingsystem/coupon/application/IssueFindCouponServiceTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/application/IssueFindCouponServiceTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class IssueCouponServiceTest {
+class IssueFindCouponServiceTest {
 
     @Mock
     private CouponCachePort couponCachePort;

--- a/coupon/src/test/java/com/orderingsystem/coupon/domain/repository/CouponRepositoryTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/domain/repository/CouponRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.orderingsystem.coupon.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CouponRepositoryTest {
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("쿠폰의 발급 수량을 지정된 숫자만큼 증가시킨다.")
+    @Test
+    void shouldIncrementCouponIssueCount_byGivenAmount() {
+        //given
+        Coupon coupon = createCoupon();
+
+        couponRepository.save(coupon);
+
+        Long increaseAmount = 5L;
+
+        //when
+        couponRepository.increaseIssuedCount(coupon.getCouponId(), increaseAmount);
+        em.clear();
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getIssuedCount()).isEqualTo(increaseAmount);
+    }
+
+    @DisplayName("쿠폰의 상태를 변경한다.")
+    @Test
+    void shouldUpdateCouponStatus() {
+        //given
+        Coupon coupon = createCoupon();
+
+        couponRepository.save(coupon);
+
+        //when
+        couponRepository.updateStatus(coupon.getCouponId(), CouponStatus.PAUSED);
+        em.clear();
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.PAUSED);
+    }
+
+    @DisplayName("만료일이 지난 활성 쿠폰들을 일괄적으로 EXPIRED 상태로 변경한다.")
+    @Test
+    void shouldExpireActiveCouponsPastValidUntil() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon expiredCoupon = createCoupon(now.minusDays(1), CouponStatus.ACTIVE);
+        Coupon validCoupon = createCoupon(now.plusDays(1), CouponStatus.ACTIVE);
+        Coupon alreadyExpired = createCoupon(now.minusDays(1), CouponStatus.EXPIRED);
+
+        couponRepository.saveAll(List.of(expiredCoupon, validCoupon, alreadyExpired));
+
+        //when
+        int updateCount = couponRepository.bulkExpireCoupons(now);
+
+        //then
+        assertThat(updateCount).isEqualTo(1);
+
+        Coupon afterExpiredCoupon = couponRepository.findById(expiredCoupon.getCouponId()).orElseThrow();
+        assertThat(afterExpiredCoupon.getStatus()).isEqualTo(CouponStatus.EXPIRED);
+
+        Coupon afterValidCoupon = couponRepository.findById(validCoupon.getCouponId()).orElseThrow();
+        assertThat(afterValidCoupon.getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+        Coupon afterAlreadyExpired = couponRepository.findById(alreadyExpired.getCouponId()).orElseThrow();
+        assertThat(afterAlreadyExpired.getStatus()).isEqualTo(CouponStatus.EXPIRED);
+    }
+
+    private Coupon createCoupon(LocalDateTime validUntil, CouponStatus couponStatus) {
+        return Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(couponStatus)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(validUntil)
+                .issueLimit(1000L)
+                .issuedCount(0L)
+                .build();
+    }
+
+    private Coupon createCoupon() {
+        return createCoupon(LocalDateTime.of(2025, 12, 20, 0, 0), CouponStatus.ACTIVE);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepositoryTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/domain/repository/IssuedCouponRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.orderingsystem.coupon.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class IssuedCouponRepositoryTest {
+
+    @Autowired
+    private IssuedCouponRepository issuedCouponRepository;
+
+    @DisplayName("만료일이 지난 발급된 쿠폰을 일괄적으로 EXPIRED 상태로 변경한다.")
+    @Test
+    void shouldExpireIssuedCouponsPastValidUntil() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        UUID couponId = UUID.randomUUID();
+
+        IssuedCoupon target = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(couponId)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(now.minusDays(10))
+                .expiredAt(now.minusDays(1))
+                .build();
+
+        IssuedCoupon alive = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(couponId)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(now.minusDays(1))
+                .expiredAt(now.plusDays(1))
+                .build();
+
+        IssuedCoupon used = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(couponId)
+                .status(IssuedCouponStatus.USED)
+                .issuedAt(now.minusDays(10))
+                .expiredAt(now.minusDays(1))
+                .usedAt(now.minusDays(2))
+                .build();
+
+        issuedCouponRepository.saveAll(List.of(target, alive, used));
+
+        //when
+        int count = issuedCouponRepository.bulkExpireIssuedCoupons(now);
+
+        //then
+        assertThat(count).isEqualTo(1);
+
+        IssuedCoupon afterTarget = issuedCouponRepository.findById(target.getId()).orElseThrow();
+        assertThat(afterTarget.getStatus()).isEqualTo(IssuedCouponStatus.EXPIRED);
+
+        IssuedCoupon afterAlive = issuedCouponRepository.findById(alive.getId()).orElseThrow();
+        assertThat(afterAlive.getStatus()).isEqualTo(IssuedCouponStatus.ISSUED);
+
+        IssuedCoupon afterUsed = issuedCouponRepository.findById(used.getId()).orElseThrow();
+        assertThat(afterUsed.getStatus()).isEqualTo(IssuedCouponStatus.USED);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponDistributionSchedulerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponDistributionSchedulerTest.java
@@ -1,0 +1,99 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.coupon.application.IssueCouponService;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.infra.redis.RedisCouponRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class CouponDistributionSchedulerTest {
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private RedisCouponRepository redisCouponRepository;
+
+    @Mock
+    private IssueCouponService issueCouponService;
+
+    @InjectMocks
+    private CouponDistributionScheduler couponDistributionScheduler;
+
+    @DisplayName("시작 시간이 현재보다 과거라면, 스케줄링 없이 즉시 Redis 등록 로직이 실행된다.")
+    @Test
+    void shouldRegisterInRedisImmediately_whenStartTimeIsInThePast() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        LocalDateTime pastDate = LocalDateTime.now().minusHours(1);
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(coupon.getValidFrom()).willReturn(pastDate);
+        given(coupon.getIssueLimit()).willReturn(100L);
+        given(coupon.getValidUntil()).willReturn(LocalDateTime.now().plusDays(1));
+
+        //when
+        couponDistributionScheduler.scheduleCouponStart(
+                couponId, coupon.getIssueLimit(), coupon.getValidFrom(), coupon.getValidUntil());
+
+        //then
+        verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+        verify(redisCouponRepository).enableCoupon(any(), any(), any());
+        verify(issueCouponService).updateCouponStatus(eq(couponId), eq(CouponStatus.ACTIVE));
+    }
+
+    @DisplayName("시작 시간이 현재보다 미래라면, TaskScheduler에 작업이 예약된다.")
+    @Test
+    void shouldScheduleTask_whenStartTimeIsInTheFuture() {
+        //given
+        UUID couponId = UUID.randomUUID();
+        LocalDateTime futureDate = LocalDateTime.now().plusHours(1);
+        Instant futureInstant = futureDate.atZone(ZoneId.systemDefault()).toInstant();
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(coupon.getValidFrom()).willReturn(futureDate);
+        given(coupon.getIssueLimit()).willReturn(100L);
+        given(coupon.getValidUntil()).willReturn(LocalDateTime.now().plusDays(1));
+
+        //when
+        couponDistributionScheduler.scheduleCouponStart(couponId, coupon.getIssueLimit(), coupon.getValidFrom(),
+                coupon.getValidUntil());
+
+        //then
+        ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        ArgumentCaptor<Instant> instantArgumentCaptor = ArgumentCaptor.forClass(Instant.class);
+
+        verify(taskScheduler).schedule(runnableArgumentCaptor.capture(), instantArgumentCaptor.capture());
+
+        assertThat(instantArgumentCaptor.getValue().getEpochSecond()).isEqualTo(futureInstant.getEpochSecond());
+
+        Runnable schedulerTask = runnableArgumentCaptor.getValue();
+        schedulerTask.run();
+
+        verify(redisCouponRepository).enableCoupon(couponId, coupon.getIssueLimit(), coupon.getValidUntil());
+        verify(issueCouponService).updateCouponStatus(couponId, CouponStatus.ACTIVE);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationSchedulerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationSchedulerTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -29,9 +32,13 @@ class CouponExpirationSchedulerTest {
     @Autowired
     private CouponRepository couponRepository;
 
+    @Autowired
+    private IssuedCouponRepository issuedCouponRepository;
+
     @AfterEach
     void tearDown() {
         couponRepository.deleteAllInBatch();
+        issuedCouponRepository.deleteAllInBatch();
     }
 
     @DisplayName("스케줄러가 실행되면 만료된 쿠폰의 상태가 변경된다.")
@@ -59,6 +66,29 @@ class CouponExpirationSchedulerTest {
         Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
         assertThat(after).isPresent();
         assertThat(after.get().getStatus()).isEqualTo(CouponStatus.EXPIRED);
+    }
+
+    @DisplayName("스케줄러가 실행되면 만료된 발급 쿠폰(IssuedCoupon)의 상태가 변경된다.")
+    @Test
+    void shouldUpdateExpiredIssuedCouponStatus_whenSchedulerRuns() {
+        //given
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(UUID.randomUUID())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.now().minusDays(2))
+                .expiredAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        issuedCouponRepository.save(issuedCoupon);
+
+        //when
+        couponExpirationScheduler.expireCoupons();
+
+        //then
+        Optional<IssuedCoupon> after = issuedCouponRepository.findById(issuedCoupon.getId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(IssuedCouponStatus.EXPIRED);
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationSchedulerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponExpirationSchedulerTest.java
@@ -1,0 +1,64 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CouponExpirationSchedulerTest {
+
+    @Autowired
+    private CouponExpirationScheduler couponExpirationScheduler;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("스케줄러가 실행되면 만료된 쿠폰의 상태가 변경된다.")
+    @Test
+    void shouldUpdateExpiredCouponStatus_whenSchedulerRuns() {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.now().minusDays(10))
+                .validUntil(LocalDateTime.now().minusMinutes(1))
+                .issueLimit(1000L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        //when
+        couponExpirationScheduler.expireCoupons();
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.EXPIRED);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponStartRunnerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/infra/scheduler/CouponStartRunnerTest.java
@@ -1,0 +1,89 @@
+package com.orderingsystem.coupon.infra.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.ApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class CouponStartRunnerTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private CouponDistributionScheduler couponDistributionScheduler;
+
+    @InjectMocks
+    private CouponStartRunner couponStartRunner;
+
+    @DisplayName("서버 시작 시 예약된 쿠폰이 있다면 스케줄러에 등록한다.")
+    @Test
+    void shouldRegisterScheduledCouponsToScheduler_onServerStartup() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon coupon1 = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .issueLimit(100L)
+                .validFrom(now.plusHours(1))
+                .validUntil(now.plusDays(1))
+                .status(CouponStatus.SCHEDULED)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .build();
+
+        Coupon coupon2 = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .issueLimit(50L)
+                .validFrom(now.plusHours(2))
+                .validUntil(now.plusDays(2))
+                .status(CouponStatus.SCHEDULED)
+                .discountType(DiscountType.PERCENTAGE)
+                .build();
+
+        given(couponRepository.findAllByStatusAndValidUntilAfter(eq(CouponStatus.SCHEDULED),
+                any(LocalDateTime.class))).willReturn(List.of(coupon1, coupon2));
+
+        //when
+        couponStartRunner.run(mock(ApplicationArguments.class));
+
+        //then
+        verify(couponDistributionScheduler, times(1)).scheduleCouponStart(coupon1.getCouponId(),
+                coupon1.getIssueLimit(), coupon1.getValidFrom(), coupon1.getValidUntil());
+        verify(couponDistributionScheduler, times(1)).scheduleCouponStart(coupon2.getCouponId(),
+                coupon2.getIssueLimit(), coupon2.getValidFrom(), coupon2.getValidUntil());
+    }
+
+    @DisplayName("서버 시작 시 예약된 쿠폰이 없다면 스케줄러를 호출하지 않는다.")
+    @Test
+    void shouldNotInvokeScheduler_whenNoScheduledCouponsExistOnStartup() {
+        //given
+        given(couponRepository.findAllByStatusAndValidUntilAfter(any(), any())).willReturn(Collections.emptyList());
+
+        //when
+        couponStartRunner.run(null);
+
+        //then
+        verify(couponDistributionScheduler, never()).scheduleCouponStart(any(), any(), any(), any());
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/ControllerTestSupport.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/ControllerTestSupport.java
@@ -1,0 +1,52 @@
+package com.orderingsystem.coupon.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.orderingsystem.common.domain.status.UserType;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public abstract class ControllerTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Value("${jwt.secret-key}")
+    protected String secretKey;
+
+    @Value("${jwt.issuer}")
+    protected String issuer;
+
+    protected String buildToken(UUID userId, UserType userType) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .issuer(issuer)
+                .claim("userId", userId.toString())
+                .claim("typ", "access")
+                .claim("role", userType.name())
+                .expiration(Date.from(Instant.now().plusSeconds(10000)))
+                .issuedAt(new Date())
+                .signWith(key, SIG.HS256)
+                .compact();
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/ControllerTestSupport.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/ControllerTestSupport.java
@@ -49,4 +49,8 @@ public abstract class ControllerTestSupport {
                 .compact();
     }
 
+    protected String buildToken(UUID userId) {
+        return buildToken(userId, UserType.CUSTOMER);
+    }
+
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
@@ -45,6 +45,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -72,6 +73,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
         assertThat(coupon.getValidUntil()).isEqualTo(request.getValidUntil());
         assertThat(coupon.getIssueLimit()).isEqualTo(request.getIssueLimit());
         assertThat(coupon.getStatus()).isEqualTo(CouponStatus.SCHEDULED);
+        assertThat(coupon.getName()).isEqualTo(request.getName());
         assertThat(coupon.getIssuedCount()).isEqualTo(0L);
     }
 
@@ -85,6 +87,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -121,6 +124,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .amountOff(BigDecimal.valueOf(2000))
+                .name("쿠폰")
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
                 .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
@@ -149,6 +153,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(-1))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -178,6 +183,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(-1))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -207,6 +213,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(null)
@@ -236,6 +243,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.PERCENTAGE)
+                .name("쿠폰")
                 .amountOff(null)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -266,6 +274,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.PERCENTAGE)
+                .name("쿠폰")
                 .percentOff(0L)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -295,6 +304,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.PERCENTAGE)
+                .name("쿠폰")
                 .percentOff(101L)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -324,6 +334,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.PERCENTAGE)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(1000))
                 .percentOff(10L)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -355,6 +366,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(null)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -385,6 +397,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .percentOff(10L)
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -410,12 +423,13 @@ class CouponControllerCreateTest extends ControllerTestSupport {
     @DisplayName("FIXED_AMOUNT 타입인데 maxDiscountAmount가 채워지면 400을 반환한다.")
     @Test
     void shouldReturn400_whenFixedAmountTypeButMaxDiscountAmountPresent() throws Exception {
-        //gvien
+        //given
         UUID userId = UUID.randomUUID();
         String token = buildToken(userId, UserType.ADMIN);
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .maxDiscountAmount(BigDecimal.valueOf(5000)) // 금지
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -447,6 +461,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.PERCENTAGE)
+                .name("쿠폰")
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(-1))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -477,6 +492,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(-1))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -506,6 +522,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -535,6 +552,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
 
         CreateCouponRequest request = CreateCouponRequest.builder()
                 .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
@@ -551,6 +569,65 @@ class CouponControllerCreateTest extends ControllerTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("periodValid: 유효기간 종료는 시작 이후여야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("쿠폰 이름이 비어있으면 쿠폰 생성에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenCouponNameIsBlank() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .name("")
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 5, 23, 59))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("name: 쿠폰 이름은 필수입니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("쿠폰 이름이 null이면 쿠폰 생성에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenCouponNameIsNull() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 5, 23, 59))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("name: 쿠폰 이름은 필수입니다."));
 
         assertThat(couponRepository.count()).isZero();
     }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
@@ -48,8 +48,8 @@ class CouponControllerCreateTest extends ControllerTestSupport {
                 .name("쿠폰")
                 .amountOff(BigDecimal.valueOf(2000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
-                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
-                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .validFrom(LocalDateTime.now().plusDays(10))
+                .validUntil(LocalDateTime.now().plusDays(20))
                 .issueLimit(10000L)
                 .validDays(10)
                 .build();
@@ -74,6 +74,49 @@ class CouponControllerCreateTest extends ControllerTestSupport {
         assertThat(coupon.getValidUntil()).isEqualTo(request.getValidUntil());
         assertThat(coupon.getIssueLimit()).isEqualTo(request.getIssueLimit());
         assertThat(coupon.getStatus()).isEqualTo(CouponStatus.SCHEDULED);
+        assertThat(coupon.getName()).isEqualTo(request.getName());
+        assertThat(coupon.getIssuedCount()).isEqualTo(0L);
+        assertThat(coupon.getValidDays()).isEqualTo(request.getValidDays());
+    }
+
+    @DisplayName("관리자 권한을 가진 유저가 쿠폰을 생성할 때 validFrom이 과거라면 바로 ACTIVE 상태가 된다.")
+    @Test
+    void shouldSetCouponActiveImmediately_whenValidFromIsPastAndUserIsAdmin() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.now().minusDays(20))
+                .validUntil(LocalDateTime.now().minusDays(10))
+                .issueLimit(10000L)
+                .validDays(10)
+                .build();
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        //then
+        List<Coupon> coupons = couponRepository.findAll();
+        assertThat(coupons.size()).isEqualTo(1);
+
+        Coupon coupon = coupons.get(0);
+        assertThat(coupon.getDiscountType()).isEqualTo(request.getDiscountType());
+        assertThat(coupon.getAmountOff().compareTo(request.getAmountOff())).isZero();
+        assertThat(coupon.getMinDiscountAmount().compareTo(request.getMinDiscountAmount())).isZero();
+        assertThat(coupon.getValidFrom()).isEqualTo(request.getValidFrom());
+        assertThat(coupon.getValidUntil()).isEqualTo(request.getValidUntil());
+        assertThat(coupon.getIssueLimit()).isEqualTo(request.getIssueLimit());
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.ACTIVE);
         assertThat(coupon.getName()).isEqualTo(request.getName());
         assertThat(coupon.getIssuedCount()).isEqualTo(0L);
         assertThat(coupon.getValidDays()).isEqualTo(request.getValidDays());

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
@@ -1,0 +1,558 @@
+package com.orderingsystem.coupon.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.presentation.request.CreateCouponRequest;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+class CouponControllerCreateTest extends ControllerTestSupport {
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("관리자 권한을 가진 유저가 쿠폰을 생성하면 쿠폰이 생성된다.")
+    @Test
+    void shouldCreateCoupon_whenUserHasAdminRole() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        //then
+        List<Coupon> coupons = couponRepository.findAll();
+        assertThat(coupons.size()).isEqualTo(1);
+
+        Coupon coupon = coupons.get(0);
+        assertThat(coupon.getDiscountType()).isEqualTo(request.getDiscountType());
+        assertThat(coupon.getAmountOff().compareTo(request.getAmountOff())).isZero();
+        assertThat(coupon.getMinDiscountAmount().compareTo(request.getMinDiscountAmount())).isZero();
+        assertThat(coupon.getValidFrom()).isEqualTo(request.getValidFrom());
+        assertThat(coupon.getValidUntil()).isEqualTo(request.getValidUntil());
+        assertThat(coupon.getIssueLimit()).isEqualTo(request.getIssueLimit());
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.SCHEDULED);
+        assertThat(coupon.getIssuedCount()).isEqualTo(0L);
+    }
+
+    @DisplayName("관리자가 아닌 유저가 쿠폰 생성시 쿠폰 생성이 불가능하고, 403을 반환한다.")
+    @ParameterizedTest(name = "[{index}] 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldReturn403_whenUserIsNotAdmin(String type, UserType userType) throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, userType);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("쿠폰 생성이 불가능합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    private static Stream<Arguments> provideNonAdminRoles() {
+        return Stream.of(
+                Arguments.of("레스토랑 소유자", UserType.RESTAURANT_OWNER),
+                Arguments.of("구매자", UserType.CUSTOMER)
+        );
+    }
+
+    @DisplayName("쿠폰 타입이 비어있으면 쿠폰 생성이 불가능하고, 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenCouponTypeIsMissing() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("discountType: 쿠폰 타입은 필수입니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("FIXED_AMOUNT 타입이며 할인 금액이 음수라면 쿠폰 생성이 불가능하다.")
+    @Test
+    void shouldReturn400_whenAmountOffIsNegative() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(-1))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("amountOff: 할인 금액은 0 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("FIXED_AMOUNT 타입이며 최소 주문 금액이 음수라면 쿠폰 생성이 불가능하다.")
+    @Test
+    void shouldReturn400_whenMinOrderAmountIsNegativeAndTypeIsFixedAmount() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(-1))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("minDiscountAmount: 최소 주문 금액은 0 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("쿠폰 발행 시작 시간이 비어있으면 쿠폰 생성이 불가능하고, 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenValidFromIsMissing() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(null)
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("validFrom: 쿠폰 발행 시작 시간은 필수입니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("PERCENTAGE 타입이며 percentOff가 비어있으면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenPercentageTypeButPercentOffMissing() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.PERCENTAGE)
+                .amountOff(null)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value(
+                        "percentRuleOk: 타입이 PERCENTAGE면 percentOff가 필수이며 amountOff는 비워야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("PERCENTAGE 타입이며 percentOff가 0이면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenPercentOffIsZero() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.PERCENTAGE)
+                .percentOff(0L)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("percentOff: 할인율은 1 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("PERCENTAGE 타입이며 percentOff가 101이면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenPercentOffIsOver100() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.PERCENTAGE)
+                .percentOff(101L)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("percentOff: 할인율은 100 이하여야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("PERCENTAGE 타입인데 amountOff가 채워지면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenPercentageTypeButAmountOffPresent() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.PERCENTAGE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .percentOff(10L)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value(
+                        "percentRuleOk: 타입이 PERCENTAGE면 percentOff가 필수이며 amountOff는 비워야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("FIXED_AMOUNT 타입인데 amountOff가 비어있으면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenFixedAmountTypeButAmountOffMissing() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(null)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value(
+                        "amountRuleOk: 쿠폰 타입이 FIXED_AMOUNT면 amountOff가 필수이며 percentOff, maxDiscountAmount는 비워야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("FIXED_AMOUNT 타입인데 percentOff가 채워지면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenFixedAmountTypeButPercentOffPresent() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .percentOff(10L)
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value(
+                        "amountRuleOk: 쿠폰 타입이 FIXED_AMOUNT면 amountOff가 필수이며 percentOff, maxDiscountAmount는 비워야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("FIXED_AMOUNT 타입인데 maxDiscountAmount가 채워지면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenFixedAmountTypeButMaxDiscountAmountPresent() throws Exception {
+        //gvien
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .maxDiscountAmount(BigDecimal.valueOf(5000)) // 금지
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value(
+                        "amountRuleOk: 쿠폰 타입이 FIXED_AMOUNT면 amountOff가 필수이며 percentOff, maxDiscountAmount는 비워야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("최대 할인 금액이 음수면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenMaxDiscountAmountIsNegative() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.PERCENTAGE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(-1))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("maxDiscountAmount: 최대 할인 금액은 0 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("최소 주문 금액이 음수면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenMinDiscountAmountIsNegative() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(-1))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("minDiscountAmount: 최소 주문 금액은 0 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("발행 개수가 음수면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenIssueLimitIsNegative() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(-1L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("issueLimit: 발행 개수는 0 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("유효기간 종료가 시작 이전이면 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenValidUntilIsBeforeValidFrom() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 3, 23, 59))
+                .issueLimit(10000L)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("periodValid: 유효기간 종료는 시작 이후여야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
@@ -51,6 +51,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
                 .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
                 .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
                 .issueLimit(10000L)
+                .validDays(10)
                 .build();
 
         //when
@@ -75,6 +76,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
         assertThat(coupon.getStatus()).isEqualTo(CouponStatus.SCHEDULED);
         assertThat(coupon.getName()).isEqualTo(request.getName());
         assertThat(coupon.getIssuedCount()).isEqualTo(0L);
+        assertThat(coupon.getValidDays()).isEqualTo(request.getValidDays());
     }
 
     @DisplayName("관리자가 아닌 유저가 쿠폰 생성시 쿠폰 생성이 불가능하고, 403을 반환한다.")
@@ -628,6 +630,68 @@ class CouponControllerCreateTest extends ControllerTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("name: 쿠폰 이름은 필수입니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("쿠폰 발급 후 유효기간이 0일이면 쿠폰 생성에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenCouponValidityIsZero() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 5, 23, 59))
+                .issueLimit(10000L)
+                .validDays(0)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("validDays: 유효 기간은 1일 이상이어야 합니다."));
+
+        assertThat(couponRepository.count()).isZero();
+    }
+
+    @DisplayName("쿠폰 발급 후 유효기간이 음수라면 쿠폰 생성에 실패하고 400을 반환한다.")
+    @Test
+    void shouldReturn400_whenCouponValidityIsNegative() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        String token = buildToken(userId, UserType.ADMIN);
+
+        CreateCouponRequest request = CreateCouponRequest.builder()
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .name("쿠폰")
+                .amountOff(BigDecimal.valueOf(2000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 4, 0, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 5, 23, 59))
+                .issueLimit(10000L)
+                .validDays(-1)
+                .build();
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("validDays: 유효 기간은 1일 이상이어야 합니다."));
 
         assertThat(couponRepository.count()).isZero();
     }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerCreateTest.java
@@ -58,7 +58,7 @@ class CouponControllerCreateTest extends ControllerTestSupport {
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         //then
         List<Coupon> coupons = couponRepository.findAll();

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -748,4 +748,206 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .build();
     }
 
+    @DisplayName("발급된 쿠폰 id로 발급한 쿠폰 정보를 조회시, DB에서 ISSUED 상태라도 만료일이 지났다면 EXPIRED 상태로 반환한다.")
+    @Test
+    void shouldReturnExpiredStatus_whenRetrievingHiddenExpiredIssuedCoupon() throws Exception {
+        //given
+        String token = buildToken(userId);
+        LocalDateTime past = LocalDateTime.now().minusDays(1);
+
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("테스트 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(past.minusDays(10))
+                .validUntil(past.plusDays(10))
+                .issueLimit(100L)
+                .build();
+        couponRepository.save(coupon);
+
+        IssuedCoupon hiddenExpiredIssuedCoupon = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(coupon.getCouponId())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(past.minusDays(5))
+                .expiredAt(past)
+                .build();
+
+        IssuedCoupon savedIssuedCoupon = issuedCouponRepository.save(hiddenExpiredIssuedCoupon);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/issued/" + savedIssuedCoupon.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issuedCouponId").value(savedIssuedCoupon.getId()))
+                .andExpect(jsonPath("$.couponName").value(coupon.getName()))
+                .andExpect(jsonPath("$.issuedCouponStatus").value(IssuedCouponStatus.EXPIRED.toString()))
+                .andExpect(jsonPath("$.expiredAt").exists());
+    }
+
+    @DisplayName("발급된 쿠폰 목록 조회(ISSUED) 시, DB상 ISSUED 상태라도 만료일이 지났다면 목록에서 제외된다.")
+    @Test
+    void shouldExcludeHiddenExpired_whenIssuedStatusIsRequested() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+        issuedCouponRepository.deleteAllInBatch();
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon coupon1 = createCoupon(now.plusDays(10));
+        couponRepository.save(coupon1);
+        IssuedCoupon realIssued = createIssuedCoupon(coupon1.getCouponId(), IssuedCouponStatus.ISSUED, now.plusDays(5));
+
+        Coupon coupon2 = createCoupon(now.minusDays(1));
+        couponRepository.save(coupon2);
+        IssuedCoupon hiddenExpired = createIssuedCoupon(coupon2.getCouponId(), IssuedCouponStatus.ISSUED, now.minusDays(1));
+
+        issuedCouponRepository.saveAll(List.of(realIssued, hiddenExpired));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ISSUED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<IssuedCouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(responses).hasSize(1)
+                .extracting("issuedCouponId", "issuedCouponStatus")
+                .containsExactly(
+                        tuple(realIssued.getId(), IssuedCouponStatus.ISSUED)
+                );
+
+        assertThat(responses).extracting("issuedCouponId")
+                .doesNotContain(hiddenExpired.getId());
+    }
+
+    @DisplayName("발급된 쿠폰 목록 조회(EXPIRED) 시, DB상 ISSUED 상태라도 만료일이 지났다면 EXPIRED로 변환되어 조회된다.")
+    @Test
+    void shouldIncludeHiddenExpired_whenExpiredStatusIsRequested() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+        issuedCouponRepository.deleteAllInBatch();
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon coupon1 = createCoupon(now.minusDays(10));
+        couponRepository.save(coupon1);
+        IssuedCoupon realExpired = createIssuedCoupon(coupon1.getCouponId(), IssuedCouponStatus.EXPIRED, now.minusDays(5));
+
+        Coupon coupon2 = createCoupon(now.minusDays(1));
+        couponRepository.save(coupon2);
+        IssuedCoupon hiddenExpired = createIssuedCoupon(coupon2.getCouponId(), IssuedCouponStatus.ISSUED, now.minusDays(1));
+
+        Coupon coupon3 = createCoupon(now.plusDays(10));
+        couponRepository.save(coupon3);
+        IssuedCoupon realIssued = createIssuedCoupon(coupon3.getCouponId(), IssuedCouponStatus.ISSUED, now.plusDays(5));
+
+        issuedCouponRepository.saveAll(List.of(realExpired, hiddenExpired, realIssued));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "EXPIRED")) // EXPIRED만 요청
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<IssuedCouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(responses).hasSize(2)
+                .extracting("issuedCouponId", "issuedCouponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(realExpired.getId(), IssuedCouponStatus.EXPIRED),
+                        tuple(hiddenExpired.getId(), IssuedCouponStatus.EXPIRED)
+                );
+    }
+
+    @DisplayName("발급된 쿠폰 목록 조회(ISSUED + EXPIRED) 시, 정상 ISSUED와 숨겨진 만료 쿠폰이 모두 조회된다.")
+    @Test
+    void shouldRetrieveBoth_whenIssuedAndExpiredRequested() throws Exception {
+        //given
+        issuedCouponRepository.deleteAllInBatch();
+        couponRepository.deleteAllInBatch();
+
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon coupon1 = createCoupon(now.plusDays(10));
+        couponRepository.save(coupon1);
+        IssuedCoupon realIssued = createIssuedCoupon(coupon1.getCouponId(), IssuedCouponStatus.ISSUED, now.plusDays(5));
+
+        Coupon coupon2 = createCoupon(now.minusDays(1));
+        couponRepository.save(coupon2);
+        IssuedCoupon hiddenExpired = createIssuedCoupon(coupon2.getCouponId(), IssuedCouponStatus.ISSUED, now.minusDays(1));
+
+        Coupon coupon3 = createCoupon(now.minusDays(10));
+        couponRepository.save(coupon3);
+        IssuedCoupon realExpired = createIssuedCoupon(coupon3.getCouponId(), IssuedCouponStatus.EXPIRED, now.minusDays(5));
+
+        Coupon coupon4 = createCoupon(now.plusDays(10));
+        couponRepository.save(coupon4);
+        IssuedCoupon usedCoupon = createIssuedCoupon(coupon4.getCouponId(), IssuedCouponStatus.USED, now.plusDays(5));
+
+        issuedCouponRepository.saveAll(List.of(realIssued, hiddenExpired, realExpired, usedCoupon));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ISSUED")
+                                .param("status", "EXPIRED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<IssuedCouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(responses).hasSize(3)
+                .extracting("issuedCouponId", "issuedCouponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(realIssued.getId(), IssuedCouponStatus.ISSUED),
+                        tuple(hiddenExpired.getId(), IssuedCouponStatus.EXPIRED),
+                        tuple(realExpired.getId(), IssuedCouponStatus.EXPIRED)
+                );
+
+        assertThat(responses).extracting("issuedCouponId")
+                .doesNotContain(usedCoupon.getId());
+    }
+
+    private Coupon createCoupon(LocalDateTime validUntil) {
+        return Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("테스트 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.now().minusDays(10))
+                .validUntil(validUntil)
+                .issueLimit(100L)
+                .build();
+    }
+
+    private IssuedCoupon createIssuedCoupon(UUID couponId, IssuedCouponStatus status, LocalDateTime expiredAt) {
+        return IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(couponId)
+                .status(status)
+                .issuedAt(LocalDateTime.now().minusDays(2))
+                .expiredAt(expiredAt)
+                .build();
+    }
+
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -369,4 +369,134 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
     }
 
+    @DisplayName("발급된 쿠폰 id로 발급한 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveIssuedCouponById_whenValidIdProvided() throws Exception {
+        //given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(coupon.getCouponId())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.now().withNano(0))
+                .expiredAt(LocalDateTime.now().plusDays(1).withNano(0))
+                .build();
+
+        IssuedCoupon savedIssuedCoupon = issuedCouponRepository.save(issuedCoupon);
+
+        String token = buildToken(userId);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/issued/" + savedIssuedCoupon.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.couponId").value(coupon.getCouponId().toString()))
+                .andExpect(jsonPath("$.couponName").value(coupon.getName()))
+                .andExpect(jsonPath("$.issuedCouponId").value(issuedCoupon.getId().toString()))
+                .andExpect(jsonPath("$.issuedCouponStatus").value(issuedCoupon.getStatus().toString()))
+                .andExpect(jsonPath("$.issuedAt").value(issuedCoupon.getIssuedAt().format(formatter)))
+                .andExpect(jsonPath("$.usedAt").value(issuedCoupon.getUsedAt()))
+                .andExpect(jsonPath("$.expiredAt").value(issuedCoupon.getExpiredAt().format(formatter)))
+                .andExpect(jsonPath("$.discountType").value(coupon.getDiscountType().toString()))
+                .andExpect(jsonPath("$.amountOff").value(coupon.getAmountOff().doubleValue()))
+                .andExpect(jsonPath("$.percentOff").value(coupon.getPercentOff()))
+                .andExpect(jsonPath("$.maxDiscountAmount").value(coupon.getMaxDiscountAmount()))
+                .andExpect(jsonPath("$.minOrderAmount").value(coupon.getMinDiscountAmount().doubleValue()));
+    }
+
+    @DisplayName("발급된 쿠폰 id로 발급한 쿠폰 정보를 조회시 쿠폰이 없으면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenIssuedCouponIdIsInvalid() throws Exception {
+        //given
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(UUID.randomUUID())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.now().withNano(0))
+                .expiredAt(LocalDateTime.now().plusDays(1).withNano(0))
+                .build();
+
+        IssuedCoupon savedIssuedCoupon = issuedCouponRepository.save(issuedCoupon);
+
+        String token = buildToken(userId);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/issued/" + savedIssuedCoupon.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
+    }
+
+    @DisplayName("발급된 쿠폰 id로 발급한 쿠폰 정보를 조회시 발급된 쿠폰 정보가 없으면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenIssuedCouponNotFoundById() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/issued/" + 10000)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("발급한 쿠폰 정보가 존재하지 않습니다."));
+    }
+
+    @DisplayName("발급된 쿠폰 id로 발급한 쿠폰 정보 조회시 본인이 발급한 쿠폰이 아니라면 403을 반환한다.")
+    @Test
+    void shouldReturn403_whenUserTriesToAccessOthersIssuedCoupon() throws Exception {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(coupon.getCouponId())
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.now().withNano(0))
+                .expiredAt(LocalDateTime.now().plusDays(1).withNano(0))
+                .build();
+
+        IssuedCoupon savedIssuedCoupon = issuedCouponRepository.save(issuedCoupon);
+
+        String token = buildToken(userId);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/issued/" + savedIssuedCoupon.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("발급한 쿠폰 정보를 조회할 권한이 없습니다."));
+    }
+
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -1,0 +1,232 @@
+package com.orderingsystem.coupon.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.model.IssuedCoupon;
+import com.orderingsystem.coupon.domain.model.IssuedCouponStatus;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MvcResult;
+
+class CouponControllerFindTest extends ControllerTestSupport {
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private IssuedCouponRepository issuedCouponRepository;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID couponId1 = UUID.randomUUID();
+    private final UUID couponId2 = UUID.randomUUID();
+    private final UUID couponId3 = UUID.randomUUID();
+    private final UUID couponId4 = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        Coupon coupon1 = Coupon.builder()
+                .couponId(couponId1)
+                .name("쿠폰1")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        Coupon coupon2 = Coupon.builder()
+                .couponId(couponId2)
+                .name("쿠폰2")
+                .discountType(DiscountType.PERCENTAGE)
+                .status(CouponStatus.ACTIVE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(3000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        Coupon coupon3 = Coupon.builder()
+                .couponId(couponId3)
+                .name("쿠폰3")
+                .discountType(DiscountType.PERCENTAGE)
+                .status(CouponStatus.ACTIVE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(3000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        Coupon coupon4 = Coupon.builder()
+                .couponId(couponId4)
+                .name("다른 사용자가 발급한 쿠폰")
+                .discountType(DiscountType.PERCENTAGE)
+                .status(CouponStatus.ACTIVE)
+                .percentOff(10L)
+                .maxDiscountAmount(BigDecimal.valueOf(3000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        couponRepository.saveAll(List.of(coupon1, coupon2, coupon3, coupon4));
+
+        IssuedCoupon issuedCoupon1 = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(couponId1)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 12, 12))
+                .expiredAt(LocalDateTime.of(2025, 12, 20, 12, 0))
+                .build();
+
+        IssuedCoupon issuedCoupon2 = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(couponId2)
+                .status(IssuedCouponStatus.EXPIRED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 12, 12))
+                .expiredAt(LocalDateTime.of(2025, 12, 20, 12, 0))
+                .build();
+
+        IssuedCoupon issuedCoupon3 = IssuedCoupon.builder()
+                .userId(userId)
+                .couponId(couponId3)
+                .status(IssuedCouponStatus.USED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 12, 12))
+                .expiredAt(LocalDateTime.of(2025, 12, 20, 12, 0))
+                .orderId(UUID.randomUUID())
+                .usedAt(LocalDateTime.of(2025, 12, 12, 12, 12))
+                .build();
+
+        IssuedCoupon issuedCoupon4 = IssuedCoupon.builder()
+                .userId(UUID.randomUUID())
+                .couponId(couponId4)
+                .status(IssuedCouponStatus.ISSUED)
+                .issuedAt(LocalDateTime.of(2025, 12, 10, 12, 12))
+                .expiredAt(LocalDateTime.of(2025, 12, 20, 12, 0))
+                .orderId(UUID.randomUUID())
+                .usedAt(LocalDateTime.of(2025, 12, 12, 12, 12))
+                .build();
+
+        issuedCouponRepository.saveAll(List.of(issuedCoupon1, issuedCoupon2, issuedCoupon3, issuedCoupon4));
+    }
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+        issuedCouponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("해당 사용자가 발급한 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveIssuedCoupons_whenUserIsValid() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ISSUED")
+                                .param("status", "USED")
+                                .param("status", "EXPIRED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+
+        List<IssuedCouponResponse> responses =
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+
+        assertThat(responses).hasSize(3)
+                .extracting("couponId", "couponName", "issuedCouponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(couponId1, "쿠폰1", IssuedCouponStatus.ISSUED),
+                        tuple(couponId2, "쿠폰2", IssuedCouponStatus.EXPIRED),
+                        tuple(couponId3, "쿠폰3", IssuedCouponStatus.USED)
+                );
+
+    }
+
+    @DisplayName("발급한 쿠폰 정보 조회시 쿠폰 발급 상태를 지정하지 않으면 ISSUED 상태의 쿠폰만 조회한다.")
+    @Test
+    void shouldRetrieveOnlyIssuedCoupons_whenStatusIsNotSpecified() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+
+        List<IssuedCouponResponse> responses =
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+
+        assertThat(responses).hasSize(1)
+                .extracting("couponId", "couponName", "issuedCouponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(couponId1, "쿠폰1", IssuedCouponStatus.ISSUED)
+                );
+
+    }
+
+    @DisplayName("발급된 쿠폰 중 특정 상태의 쿠폰만 조회할 수 있다.")
+    @Test
+    void shouldRetrieveCouponsByStatusFilter_whenUserIsValid() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons/issued")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "USED")
+                                .param("status", "EXPIRED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+
+        List<IssuedCouponResponse> responses =
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+
+        assertThat(responses).hasSize(2)
+                .extracting("couponId", "couponName", "issuedCouponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(couponId2, "쿠폰2", IssuedCouponStatus.EXPIRED),
+                        tuple(couponId3, "쿠폰3", IssuedCouponStatus.USED)
+                );
+
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -3,6 +3,7 @@ package com.orderingsystem.coupon.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -17,6 +18,7 @@ import com.orderingsystem.coupon.domain.repository.CouponRepository;
 import com.orderingsystem.coupon.domain.repository.IssuedCouponRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -306,6 +308,65 @@ class CouponControllerFindTest extends ControllerTestSupport {
                                 null
                         )
                 );
+    }
+
+    @DisplayName("쿠폰 id로 쿠폰 정보를 조회할 수 있다.")
+    @Test
+    void shouldRetrieveCouponByCouponCode_whenValidCodeProvided() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
+                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .issueLimit(1000L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/" + coupon.getCouponId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.couponId").value(coupon.getCouponId().toString()))
+                .andExpect(jsonPath("$.couponName").value(coupon.getName()))
+                .andExpect(jsonPath("$.discountType").value(coupon.getDiscountType().toString()))
+                .andExpect(jsonPath("$.couponStatus").value(coupon.getStatus().toString()))
+                .andExpect(jsonPath("$.amountOff").value(coupon.getAmountOff().doubleValue()))
+                .andExpect(jsonPath("$.percentOff").value(coupon.getPercentOff()))
+                .andExpect(jsonPath("$.maxDiscountAmount").value(coupon.getMaxDiscountAmount()))
+                .andExpect(jsonPath("$.minDiscountAmount").value(coupon.getMinDiscountAmount().doubleValue()))
+                .andExpect(jsonPath("$.validFrom").value(coupon.getValidFrom().format(formatter)))
+                .andExpect(jsonPath("$.validUntil").value(coupon.getValidUntil().format(formatter)))
+                .andExpect(jsonPath("$.validDays").value(coupon.getValidDays()))
+                .andExpect(jsonPath("$.issueLimit").value(coupon.getIssueLimit()))
+                .andExpect(jsonPath("$.issuedCount").value(coupon.getIssuedCount()));
+    }
+
+    @DisplayName("쿠폰 id로 쿠폰 정보 조회시 쿠폰이 없으면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenCouponCodeIsInvalid() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/" + UUID.randomUUID())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.orderingsystem.coupon.application.dto.response.CouponResponse;
 import com.orderingsystem.coupon.application.dto.response.IssuedCouponResponse;
 import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
@@ -58,7 +59,7 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .couponId(couponId2)
                 .name("쿠폰2")
                 .discountType(DiscountType.PERCENTAGE)
-                .status(CouponStatus.ACTIVE)
+                .status(CouponStatus.SCHEDULED)
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(3000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -71,7 +72,7 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .couponId(couponId3)
                 .name("쿠폰3")
                 .discountType(DiscountType.PERCENTAGE)
-                .status(CouponStatus.ACTIVE)
+                .status(CouponStatus.ARCHIVED)
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(3000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -84,7 +85,7 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .couponId(couponId4)
                 .name("다른 사용자가 발급한 쿠폰")
                 .discountType(DiscountType.PERCENTAGE)
-                .status(CouponStatus.ACTIVE)
+                .status(CouponStatus.PAUSED)
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(3000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
@@ -160,7 +161,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
         String json = mvcResult.getResponse().getContentAsString();
 
         List<IssuedCouponResponse> responses =
-                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {
+                });
 
         assertThat(responses).hasSize(3)
                 .extracting("couponId", "couponName", "issuedCouponStatus")
@@ -189,7 +191,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
         String json = mvcResult.getResponse().getContentAsString();
 
         List<IssuedCouponResponse> responses =
-                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {
+                });
 
         assertThat(responses).hasSize(1)
                 .extracting("couponId", "couponName", "issuedCouponStatus")
@@ -218,7 +221,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
         String json = mvcResult.getResponse().getContentAsString();
 
         List<IssuedCouponResponse> responses =
-                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {});
+                objectMapper.readValue(json, new TypeReference<List<IssuedCouponResponse>>() {
+                });
 
         assertThat(responses).hasSize(2)
                 .extracting("couponId", "couponName", "issuedCouponStatus")
@@ -227,6 +231,81 @@ class CouponControllerFindTest extends ControllerTestSupport {
                         tuple(couponId3, "쿠폰3", IssuedCouponStatus.USED)
                 );
 
+    }
+
+    @DisplayName("쿠폰 상태(status)에 따라 사용자가 발급받은 쿠폰을 필터링 조회할 수 있다.")
+    @Test
+    void shouldFilterUserCouponsByStatus_whenValidStatusesAreProvided() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ACTIVE")
+                                .param("status", "SCHEDULED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+
+        List<CouponResponse> responses =
+                objectMapper.readValue(json, new TypeReference<List<CouponResponse>>() {
+                });
+
+        assertThat(responses).hasSize(2)
+                .extracting("couponId", "couponName", "couponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(couponId1, "쿠폰1", CouponStatus.ACTIVE),
+                        tuple(couponId2, "쿠폰2", CouponStatus.SCHEDULED)
+                );
+    }
+
+    @DisplayName("쿠폰 조회시 상태를 지정하지 않으면 ACTIVE 상태의 쿠폰을 조회한다.")
+    @Test
+    void shouldRetrieveOnlyActiveCoupons_whenStatusIsNotProvided() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+
+        List<CouponResponse> responses =
+                objectMapper.readValue(json, new TypeReference<List<CouponResponse>>() {
+                });
+
+        assertThat(responses).hasSize(1)
+                .extracting(
+                        "couponId", "couponName", "discountType", "couponStatus", "amountOff", "percentOff",
+                        "maxDiscountAmount", "minDiscountAmount", "validFrom", "validUntil", "validDays", "issueLimit",
+                        "issuedCount"
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(
+                                couponId1,
+                                "쿠폰1",
+                                DiscountType.FIXED_AMOUNT,
+                                CouponStatus.ACTIVE,
+                                new BigDecimal("1000.00"),
+                                null,
+                                null,
+                                new BigDecimal("10000.00"),
+                                LocalDateTime.of(2025, 12, 10, 12, 0),
+                                LocalDateTime.of(2025, 12, 20, 0, 0),
+                                null,
+                                1000L,
+                                null
+                        )
+                );
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerFindTest.java
@@ -52,8 +52,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .status(CouponStatus.ACTIVE)
                 .amountOff(BigDecimal.valueOf(1000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
-                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
-                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .validFrom(LocalDateTime.now().minusDays(1))
+                .validUntil(LocalDateTime.now().plusDays(10))
                 .issueLimit(1000L)
                 .build();
 
@@ -65,8 +65,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(3000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
-                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
-                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .validFrom(LocalDateTime.now().minusDays(10))
+                .validUntil(LocalDateTime.now().minusMinutes(1))
                 .issueLimit(1000L)
                 .build();
 
@@ -78,8 +78,8 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .percentOff(10L)
                 .maxDiscountAmount(BigDecimal.valueOf(3000))
                 .minDiscountAmount(BigDecimal.valueOf(10000))
-                .validFrom(LocalDateTime.of(2025, 12, 10, 12, 0))
-                .validUntil(LocalDateTime.of(2025, 12, 20, 0, 0))
+                .validFrom(LocalDateTime.now().plusDays(1))
+                .validUntil(LocalDateTime.now().plusDays(10))
                 .issueLimit(1000L)
                 .build();
 
@@ -288,7 +288,7 @@ class CouponControllerFindTest extends ControllerTestSupport {
         assertThat(responses).hasSize(1)
                 .extracting(
                         "couponId", "couponName", "discountType", "couponStatus", "amountOff", "percentOff",
-                        "maxDiscountAmount", "minDiscountAmount", "validFrom", "validUntil", "validDays", "issueLimit",
+                        "maxDiscountAmount", "minDiscountAmount", "validDays", "issueLimit",
                         "issuedCount"
                 )
                 .containsExactlyInAnyOrder(
@@ -301,8 +301,6 @@ class CouponControllerFindTest extends ControllerTestSupport {
                                 null,
                                 null,
                                 new BigDecimal("10000.00"),
-                                LocalDateTime.of(2025, 12, 10, 12, 0),
-                                LocalDateTime.of(2025, 12, 20, 0, 0),
                                 null,
                                 1000L,
                                 null
@@ -497,6 +495,257 @@ class CouponControllerFindTest extends ControllerTestSupport {
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value("Forbidden"))
                 .andExpect(jsonPath("$.message").value("발급한 쿠폰 정보를 조회할 권한이 없습니다."));
+    }
+
+    @DisplayName("ACTIVE 상태 조회 시, DB상 ACTIVE라도 유효기간이 지난 쿠폰은 결과에서 제외된다.")
+    @Test
+    void shouldExcludeExpiredActiveCoupons_whenActiveStatusIsRequested() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon realActive = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("진짜 유효한 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(now.minusDays(1))
+                .validUntil(now.plusDays(1))
+                .issueLimit(100L)
+                .build();
+
+        Coupon hiddenExpired = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("기간 지난 활성 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(now.minusDays(5))
+                .validUntil(now.minusDays(1))
+                .issueLimit(100L)
+                .build();
+
+        couponRepository.saveAll(List.of(realActive, hiddenExpired));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ACTIVE"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<CouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {
+        });
+
+        assertThat(responses).hasSize(1)
+                .extracting("couponId", "couponName", "couponStatus")
+                .containsExactly(
+                        tuple(realActive.getCouponId(), "진짜 유효한 쿠폰", CouponStatus.ACTIVE)
+                );
+
+        assertThat(responses).extracting("couponId")
+                .doesNotContain(hiddenExpired.getCouponId());
+    }
+
+    @DisplayName("EXPIRED 상태 조회 시, DB상 EXPIRED인 쿠폰과 ACTIVE지만 유효기간이 지난 쿠폰이 모두 조회된다.")
+    @Test
+    void shouldIncludeHiddenExpiredCoupons_whenExpiredStatusIsRequested() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon realExpired = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("이미 만료된 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.EXPIRED)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(now.minusDays(10))
+                .validUntil(now.minusDays(5))
+                .issueLimit(100L)
+                .build();
+
+        Coupon hiddenExpired = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("기간 지난 활성 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(now.minusDays(5))
+                .validUntil(now.minusDays(1))
+                .issueLimit(100L)
+                .build();
+
+        Coupon realActive = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("지금 유효한 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(now.minusDays(1))
+                .validUntil(now.plusDays(1))
+                .issueLimit(100L)
+                .build();
+
+        couponRepository.saveAll(List.of(realExpired, hiddenExpired, realActive));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "EXPIRED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<CouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {
+        });
+
+        assertThat(responses).hasSize(2)
+                .extracting("couponId", "couponName", "couponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(realExpired.getCouponId(), "이미 만료된 쿠폰", CouponStatus.EXPIRED),
+                        tuple(hiddenExpired.getCouponId(), "기간 지난 활성 쿠폰", CouponStatus.EXPIRED)
+                );
+    }
+
+    @DisplayName("ACTIVE와 PAUSED 상태를 함께 조회하면, 유효기간이 지난 ACTIVE는 제외되고 조회된다.")
+    @Test
+    void shouldRetrieveActiveAndPausedCoupons_excludingHiddenExpired() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon realActive = createCoupon(CouponStatus.ACTIVE, now.plusDays(1));
+        Coupon paused = createCoupon(CouponStatus.PAUSED, now.plusDays(1));
+        Coupon hiddenExpired = createCoupon(CouponStatus.ACTIVE, now.minusDays(1));
+        Coupon realExpired = createCoupon(CouponStatus.EXPIRED, now.minusDays(5));
+
+        couponRepository.saveAll(List.of(realActive, paused, hiddenExpired, realExpired));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "ACTIVE")
+                                .param("status", "PAUSED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<CouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {
+        });
+
+        assertThat(responses).hasSize(2)
+                .extracting("couponId", "couponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(realActive.getCouponId(), CouponStatus.ACTIVE),
+                        tuple(paused.getCouponId(), CouponStatus.PAUSED)
+                );
+
+        assertThat(responses).extracting("couponId")
+                .doesNotContain(hiddenExpired.getCouponId());
+    }
+
+    @DisplayName("EXPIRED와 SCHEDULED 상태를 함께 조회하면, 숨겨진 만료 쿠폰도 포함되어 조회된다.")
+    @Test
+    void shouldRetrieveExpiredAndScheduledCoupons_includingHiddenExpired() throws Exception {
+        //given
+        couponRepository.deleteAllInBatch();
+        String token = buildToken(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        Coupon realExpired = createCoupon(CouponStatus.EXPIRED, now.minusDays(5));
+        Coupon hiddenExpired = createCoupon(CouponStatus.ACTIVE, now.minusDays(1));
+        Coupon scheduled = createCoupon(CouponStatus.SCHEDULED, now.plusDays(10));
+        Coupon realActive = createCoupon(CouponStatus.ACTIVE, now.plusDays(1));
+
+        couponRepository.saveAll(List.of(realExpired, hiddenExpired, scheduled, realActive));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/coupons")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .param("status", "EXPIRED")
+                                .param("status", "SCHEDULED"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        List<CouponResponse> responses = objectMapper.readValue(json, new TypeReference<>() {
+        });
+
+        assertThat(responses).hasSize(3)
+                .extracting("couponId", "couponStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(realExpired.getCouponId(), CouponStatus.EXPIRED),
+                        tuple(hiddenExpired.getCouponId(), CouponStatus.EXPIRED),
+                        tuple(scheduled.getCouponId(), CouponStatus.SCHEDULED)
+                );
+    }
+
+    @DisplayName("쿠폰 id로 쿠폰 조회 시, DB에서 ACTIVE 상태라도 유효기간이 지났다면 EXPIRED 상태로 반환한다.")
+    @Test
+    void shouldReturnExpiredStatus_whenRetrievingHiddenExpiredCoupon() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        LocalDateTime past = LocalDateTime.now().minusDays(1);
+
+        Coupon hiddenExpiredCoupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("기간 지난 활성 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(CouponStatus.ACTIVE)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(past.minusDays(10))
+                .validUntil(past)
+                .issueLimit(100L)
+                .build();
+
+        couponRepository.save(hiddenExpiredCoupon);
+
+        //when, then
+        mockMvc.perform(
+                        get("/api/coupons/" + hiddenExpiredCoupon.getCouponId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.couponId").value(hiddenExpiredCoupon.getCouponId().toString()))
+                .andExpect(jsonPath("$.couponName").value(hiddenExpiredCoupon.getName()))
+                .andExpect(jsonPath("$.couponStatus").value(CouponStatus.EXPIRED.toString()))
+                .andExpect(jsonPath("$.validUntil").exists());
+    }
+
+    private Coupon createCoupon(CouponStatus status, LocalDateTime validUntil) {
+        return Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("테스트 쿠폰")
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .status(status)
+                .amountOff(BigDecimal.valueOf(1000))
+                .minDiscountAmount(BigDecimal.valueOf(10000))
+                .validFrom(LocalDateTime.now().minusDays(10))
+                .validUntil(validUntil)
+                .issueLimit(100L)
+                .build();
     }
 
 }

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerIssueTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponControllerIssueTest.java
@@ -1,0 +1,158 @@
+package com.orderingsystem.coupon.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.orderingsystem.common.util.RedisTransaction;
+import com.orderingsystem.coupon.application.port.out.CouponIssueMessagePublisher;
+import com.orderingsystem.coupon.domain.event.CouponIssuedEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class CouponControllerIssueTest extends ControllerTestSupport {
+
+    @TestConfiguration
+    static class TestRedisConfig {
+        @Bean
+        public RedisTransaction redisTransaction() {
+            return new RedisTransaction() {
+                @Override
+                public void execute(RedisTemplate<String, String> redisTemplate,
+                                    java.util.function.Consumer<RedisOperations<String, String>> callback) {
+                    callback.accept(redisTemplate);
+                }
+            };
+        }
+    }
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @MockitoBean
+    private CouponIssueMessagePublisher couponIssueMessagePublisher;
+
+    @Value("${coupon.redis.stock-prefix}")
+    private String stockPrefix;
+
+    @Value("${coupon.redis.issued-prefix}")
+    private String issuedPrefix;
+
+    private final UUID couponId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+
+    private String stockKey(UUID couponId) {
+        return stockPrefix + couponId;
+    }
+
+    private String issuedKey(UUID couponId) {
+        return issuedPrefix + couponId;
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(stockKey(couponId));
+    }
+
+    @DisplayName("재고가 있고 최초 발급이면 쿠폰이 발급되고, 발급 이벤트가 발행된다.")
+    @Test
+    void shouldIssueCoupon_whenStockExistsAndFirstIssue() throws Exception {
+        //given
+        redisTemplate.opsForValue().set(stockKey(couponId), "2000");
+        String token = buildToken(userId);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + couponId + "/claims")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+
+        //then
+        assertThat(redisTemplate.opsForValue().get(stockKey(couponId))).isEqualTo("1999");
+        assertThat(redisTemplate.opsForSet().members(issuedKey(couponId))).contains(userId.toString());
+
+        ArgumentCaptor<CouponIssuedEvent> captor = ArgumentCaptor.forClass(CouponIssuedEvent.class);
+        verify(couponIssueMessagePublisher, times(1)).publish(captor.capture());
+
+        CouponIssuedEvent event = captor.getValue();
+        assertThat(event.getCouponId()).isEqualTo(couponId);
+        assertThat(event.getUserId()).isEqualTo(userId);
+        assertThat(event.getCreatedAt()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 쿠폰 발급 요청을 보내면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenCouponKeyDoesNotExist() throws Exception {
+        //given
+        String token = buildToken(userId);
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons/" + couponId + "/claims")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 쿠폰입니다."));
+    }
+
+    @DisplayName("요청한 쿠폰을 이미 발급했으면 400을 반환하고 쿠폰 발급에 실패한다.")
+    @Test
+    void shouldReturn400_whenAlreadyIssued() throws Exception {
+        //given
+        redisTemplate.opsForValue().set(stockKey(couponId), "2000");
+        redisTemplate.opsForSet().add(issuedKey(couponId), userId.toString());
+        String token = buildToken(userId);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + couponId + "/claims")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("이미 쿠폰이 발급되었습니다."));
+
+        //then
+        assertThat(redisTemplate.opsForValue().get(stockKey(couponId))).isEqualTo("2000");
+        assertThat(redisTemplate.opsForSet().members(issuedKey(couponId))).contains(userId.toString());
+
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+    @DisplayName("재고가 없으면 400을 반환하고 쿠폰 발급에 실패한다.")
+    @Test
+    void shouldReturn400_whenSoldOut() throws Exception {
+        //given
+        redisTemplate.opsForValue().set(stockKey(couponId), "0");
+        String token = buildToken(userId);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + couponId + "/claims")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 마감되었습니다."));
+
+        //then
+        assertThat(redisTemplate.opsForValue().get(stockKey(couponId))).isEqualTo("0");
+        assertThat(redisTemplate.opsForSet().members(issuedKey(couponId))).doesNotContain(userId.toString());
+
+        verifyNoInteractions(couponIssueMessagePublisher);
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 
 class CouponManagementControllerTest extends ControllerTestSupport {
@@ -32,6 +34,12 @@ class CouponManagementControllerTest extends ControllerTestSupport {
 
     @Autowired
     private RedisCouponRepository redisCouponRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Value("${coupon.redis.issued-prefix}")
+    private String couponIssueKey;
 
     @AfterEach
     void tearDown() {
@@ -239,6 +247,15 @@ class CouponManagementControllerTest extends ControllerTestSupport {
         assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
     }
 
+    private static Stream<Arguments> provideNonPauseStatuses() {
+        return Stream.of(
+                Arguments.of("활성화된 쿠폰", CouponStatus.ACTIVE),
+                Arguments.of("활성화 대기중", CouponStatus.SCHEDULED),
+                Arguments.of("만료된 쿠폰", CouponStatus.EXPIRED),
+                Arguments.of("보관된 쿠폰", CouponStatus.ARCHIVED)
+        );
+    }
+
     @DisplayName("재시작할 쿠폰이 존재하지 않으면 404를 반환한다.")
     @Test
     void shouldReturn404_whenCouponToReactivateDoesNotExist() throws Exception {
@@ -254,19 +271,116 @@ class CouponManagementControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
     }
 
+    @DisplayName("관리자는 정지된 쿠폰을 종료할 수 있다.")
+    @Test
+    void shouldExpireCoupon_whenUserIsAdminAndCouponIsPaused() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.PAUSED)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .issueLimit(100L)
+                .issuedCount(10L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        redisCouponRepository.enableCoupon(coupon.getCouponId(), coupon.getIssueLimit(), null);
+        redisCouponRepository.addIssuedUser(coupon.getCouponId(), userId);
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/terminate")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.ARCHIVED);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+
+        String issuedKey = couponIssueKey + coupon.getCouponId();
+        Long ttl = redisTemplate.getExpire(issuedKey);
+        assertThat(ttl).isGreaterThan(0L);
+        assertThat(ttl).isLessThanOrEqualTo(604800L);
+    }
+
+    @DisplayName("관리자가 아니라면 쿠폰을 종료할 수 없고 403을 반환한다.")
+    @ParameterizedTest(name = "[{index}] 유저 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldReturn403_whenNonAdminUserTriesToExpireSuspendedCoupon(String role, UserType userType)
+            throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.ACTIVE)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .issueLimit(100L)
+                .issuedCount(10L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        redisCouponRepository.enableCoupon(coupon.getCouponId(), coupon.getIssueLimit(), null);
+        redisCouponRepository.addIssuedUser(coupon.getCouponId(), userId);
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+
+        String token = buildToken(UUID.randomUUID(), userType);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/terminate")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("쿠폰 종료가 불가능합니다."));
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+
+        String issuedKey = couponIssueKey + coupon.getCouponId();
+        Long ttl = redisTemplate.getExpire(issuedKey);
+        assertThat(ttl).isEqualTo(-1L);
+    }
+
+    @DisplayName("종료할 쿠폰이 존재하지 않으면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenCouponToExpireDoesNotExist() throws Exception {
+        //given
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons/" + UUID.randomUUID() + "/terminate")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
+    }
+
     private static Stream<Arguments> provideNonAdminRoles() {
         return Stream.of(
                 Arguments.of("구매자", UserType.CUSTOMER),
                 Arguments.of("레스토랑 소유자", UserType.RESTAURANT_OWNER)
-        );
-    }
-
-    private static Stream<Arguments> provideNonPauseStatuses() {
-        return Stream.of(
-                Arguments.of("활성화된 쿠폰", CouponStatus.ACTIVE),
-                Arguments.of("활성화 대기중", CouponStatus.SCHEDULED),
-                Arguments.of("만료된 쿠폰", CouponStatus.EXPIRED),
-                Arguments.of("보관된 쿠폰", CouponStatus.ARCHIVED)
         );
     }
 

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
@@ -1,0 +1,120 @@
+package com.orderingsystem.coupon.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.coupon.domain.model.Coupon;
+import com.orderingsystem.coupon.domain.model.CouponStatus;
+import com.orderingsystem.coupon.domain.model.DiscountType;
+import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+class CouponManagementControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("관리자는 쿠폰을 정지시킬 수 있다.")
+    @Test
+    void shouldDeactivateCoupon_whenUserHasAdminRole() throws Exception{
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.ACTIVE)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .build();
+
+        couponRepository.save(coupon);
+
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/pause")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.PAUSED);
+    }
+
+    @DisplayName("관리자가 아닌 유저는 쿠폰을 정지시킬 수 없고, 403을 반환한다.")
+    @ParameterizedTest(name = "[{index}] 유저 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldReturn403_whenUserWithoutAdminRoleTriesToDeactivateCoupon(String role, UserType userType) throws Exception{
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.ACTIVE)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .build();
+
+        couponRepository.save(coupon);
+
+        String token = buildToken(UUID.randomUUID(), userType);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/pause")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("쿠폰 정지가 불가능합니다."));
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.ACTIVE);
+    }
+
+    private static Stream<Arguments> provideNonAdminRoles(){
+        return Stream.of(
+                Arguments.of("구매자",UserType.CUSTOMER),
+                Arguments.of("레스토랑 소유자",UserType.RESTAURANT_OWNER)
+        );
+    }
+
+    @DisplayName("쿠폰을 정지하려할 때 쿠폰이 존재하지 않으면 404를 반환한디.")
+    @Test
+    void shouldReturn404_whenCouponToDeactivateDoesNotExist() throws Exception{
+        //given
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons/" + UUID.randomUUID()+ "/pause")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
+    }
+
+}

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
@@ -10,6 +10,7 @@ import com.orderingsystem.coupon.domain.model.Coupon;
 import com.orderingsystem.coupon.domain.model.CouponStatus;
 import com.orderingsystem.coupon.domain.model.DiscountType;
 import com.orderingsystem.coupon.domain.repository.CouponRepository;
+import com.orderingsystem.coupon.infra.redis.RedisCouponRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -28,6 +29,9 @@ class CouponManagementControllerTest extends ControllerTestSupport {
 
     @Autowired
     private CouponRepository couponRepository;
+
+    @Autowired
+    private RedisCouponRepository redisCouponRepository;
 
     @AfterEach
     void tearDown() {
@@ -49,6 +53,9 @@ class CouponManagementControllerTest extends ControllerTestSupport {
 
         couponRepository.save(coupon);
 
+        redisCouponRepository.enableCoupon(coupon.getCouponId(), 1000L, LocalDateTime.now());
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+
         String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
 
         //when
@@ -61,6 +68,8 @@ class CouponManagementControllerTest extends ControllerTestSupport {
         Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
         assertThat(after).isPresent();
         assertThat(after.get().getStatus()).isEqualTo(CouponStatus.PAUSED);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
     }
 
     @DisplayName("관리자가 아닌 유저는 쿠폰을 정지시킬 수 없고, 403을 반환한다.")
@@ -79,6 +88,9 @@ class CouponManagementControllerTest extends ControllerTestSupport {
 
         couponRepository.save(coupon);
 
+        redisCouponRepository.enableCoupon(coupon.getCouponId(), 1000L, LocalDateTime.now());
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+
         String token = buildToken(UUID.randomUUID(), userType);
 
         //when
@@ -93,6 +105,8 @@ class CouponManagementControllerTest extends ControllerTestSupport {
         Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
         assertThat(after).isPresent();
         assertThat(after.get().getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
     }
 
     private static Stream<Arguments> provideNonAdminRoles(){

--- a/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
+++ b/coupon/src/test/java/com/orderingsystem/coupon/presentation/CouponManagementControllerTest.java
@@ -40,7 +40,7 @@ class CouponManagementControllerTest extends ControllerTestSupport {
 
     @DisplayName("관리자는 쿠폰을 정지시킬 수 있다.")
     @Test
-    void shouldDeactivateCoupon_whenUserHasAdminRole() throws Exception{
+    void shouldDeactivateCoupon_whenUserHasAdminRole() throws Exception {
         //given
         Coupon coupon = Coupon.builder()
                 .couponId(UUID.randomUUID())
@@ -75,7 +75,8 @@ class CouponManagementControllerTest extends ControllerTestSupport {
     @DisplayName("관리자가 아닌 유저는 쿠폰을 정지시킬 수 없고, 403을 반환한다.")
     @ParameterizedTest(name = "[{index}] 유저 권한 : {0}")
     @MethodSource("provideNonAdminRoles")
-    void shouldReturn403_whenUserWithoutAdminRoleTriesToDeactivateCoupon(String role, UserType userType) throws Exception{
+    void shouldReturn403_whenUserWithoutAdminRoleTriesToDeactivateCoupon(String role, UserType userType)
+            throws Exception {
         //given
         Coupon coupon = Coupon.builder()
                 .couponId(UUID.randomUUID())
@@ -109,26 +110,164 @@ class CouponManagementControllerTest extends ControllerTestSupport {
         assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
     }
 
-    private static Stream<Arguments> provideNonAdminRoles(){
-        return Stream.of(
-                Arguments.of("구매자",UserType.CUSTOMER),
-                Arguments.of("레스토랑 소유자",UserType.RESTAURANT_OWNER)
-        );
-    }
-
     @DisplayName("쿠폰을 정지하려할 때 쿠폰이 존재하지 않으면 404를 반환한디.")
     @Test
-    void shouldReturn404_whenCouponToDeactivateDoesNotExist() throws Exception{
+    void shouldReturn404_whenCouponToDeactivateDoesNotExist() throws Exception {
         //given
         String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
 
         //when, then
         mockMvc.perform(
-                        post("/api/coupons/" + UUID.randomUUID()+ "/pause")
+                        post("/api/coupons/" + UUID.randomUUID() + "/pause")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("Not Found"))
                 .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
+    }
+
+    @DisplayName("관리자는 정지된 쿠폰을 재시작할 수 있다.")
+    @Test
+    void shouldReactivateCoupon_whenUserHasAdminRoleAndCouponIsSuspended() throws Exception {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.PAUSED)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .issueLimit(100L)
+                .issuedCount(10L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/resume")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isTrue();
+        assertThat(redisCouponRepository.currentStock(coupon.getCouponId())).isEqualTo(90L);
+    }
+
+    @DisplayName("관리자가 아니라면 정지된 쿠폰을 재시작할 수 없고 403을 반환한다.")
+    @ParameterizedTest(name = "[{index}] 유저 권한 : {0}")
+    @MethodSource("provideNonAdminRoles")
+    void shouldReturn403_whenNonAdminUserTriesToReactivateSuspendedCoupon(String role, UserType userType)
+            throws Exception {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(CouponStatus.PAUSED)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .issueLimit(100L)
+                .issuedCount(10L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+
+        String token = buildToken(UUID.randomUUID(), userType);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/resume")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("쿠폰 재시작이 불가능합니다."));
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(CouponStatus.PAUSED);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+    }
+
+    @DisplayName("PAUSE 상태가 아닌 쿠폰은 재시작이 불가능하고 400을 반환한다.")
+    @ParameterizedTest(name = "[{index}] 쿠폰 상태 : {0}")
+    @MethodSource("provideNonPauseStatuses")
+    void shouldReturn400_whenTryingToReactivateCouponWithInvalidStatus(String status, CouponStatus couponStatus)
+            throws Exception {
+        //given
+        Coupon coupon = Coupon.builder()
+                .couponId(UUID.randomUUID())
+                .name("쿠폰")
+                .status(couponStatus)
+                .discountType(DiscountType.FIXED_AMOUNT)
+                .amountOff(BigDecimal.valueOf(1000))
+                .validFrom(LocalDateTime.of(2025, 12, 14, 0, 0))
+                .issueLimit(100L)
+                .issuedCount(10L)
+                .build();
+
+        couponRepository.save(coupon);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when
+        mockMvc.perform(
+                        post("/api/coupons/" + coupon.getCouponId() + "/resume")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("정지된 쿠폰만 재시작할 수 있습니다."));
+
+        //then
+        Optional<Coupon> after = couponRepository.findById(coupon.getCouponId());
+        assertThat(after).isPresent();
+        assertThat(after.get().getStatus()).isEqualTo(couponStatus);
+
+        assertThat(redisCouponRepository.exists(coupon.getCouponId())).isFalse();
+    }
+
+    @DisplayName("재시작할 쿠폰이 존재하지 않으면 404를 반환한다.")
+    @Test
+    void shouldReturn404_whenCouponToReactivateDoesNotExist() throws Exception {
+        //given
+        String token = buildToken(UUID.randomUUID(), UserType.ADMIN);
+
+        //when, then
+        mockMvc.perform(
+                        post("/api/coupons/" + UUID.randomUUID() + "/resume")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("쿠폰이 존재하지 않습니다."));
+    }
+
+    private static Stream<Arguments> provideNonAdminRoles() {
+        return Stream.of(
+                Arguments.of("구매자", UserType.CUSTOMER),
+                Arguments.of("레스토랑 소유자", UserType.RESTAURANT_OWNER)
+        );
+    }
+
+    private static Stream<Arguments> provideNonPauseStatuses() {
+        return Stream.of(
+                Arguments.of("활성화된 쿠폰", CouponStatus.ACTIVE),
+                Arguments.of("활성화 대기중", CouponStatus.SCHEDULED),
+                Arguments.of("만료된 쿠폰", CouponStatus.EXPIRED),
+                Arguments.of("보관된 쿠폰", CouponStatus.ARCHIVED)
+        );
     }
 
 }

--- a/infrastructure/src/main/java/com/orderingsystem/docker-compose/init_kafka.yml
+++ b/infrastructure/src/main/java/com/orderingsystem/docker-compose/init_kafka.yml
@@ -13,6 +13,7 @@ services:
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --delete --topic restaurant-request --if-exists
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --delete --topic restaurant-response --if-exists
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --delete --topic customer --if-exists
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --delete --topic ordering.coupon.issue.request --if-exists
 
       echo 'Creating topics...' 
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --create --if-not-exists --topic payment-request --replication-factor 3 --partitions 3 
@@ -20,6 +21,7 @@ services:
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --create --if-not-exists --topic restaurant-request --replication-factor 3 --partitions 3
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --create --if-not-exists --topic restaurant-response --replication-factor 3 --partitions 3
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --create --if-not-exists --topic customer --replication-factor 3 --partitions 3
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --create --if-not-exists --topic ordering.coupon.issue.request --replication-factor 3 --partitions 3
 
       /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka-1:9092 --list
       "

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/infra/redis/RedisStockRepository.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/infra/redis/RedisStockRepository.java
@@ -14,9 +14,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Repository;
 
-@Service
+@Repository
 @RequiredArgsConstructor
 @Slf4j
 public class RedisStockRepository implements StockCachePort {

--- a/restaurant/src/main/java/com/orderingsystem/restaurant/infra/redis/RedisStockRepository.java
+++ b/restaurant/src/main/java/com/orderingsystem/restaurant/infra/redis/RedisStockRepository.java
@@ -131,7 +131,6 @@ public class RedisStockRepository implements StockCachePort {
             throw new IllegalStateException("재고 데이터가 존재하지 않습니다. " + history.keySet());
         }
 
-        System.out.println("<<<<  " + confirmedKey(orderId) + " " + history.toString());
         redisTemplate.opsForHash().putAll(confirmedKey(orderId), history);
 
         log.info("{} 주문 예약 확정 완료. Redis 실제 재고 차감 및 예약 해제", sagaId);

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,6 @@ include 'order'
 include 'payment'
 include 'restaurant'
 include 'user'
+include 'coupon'
+
 

--- a/user/src/main/java/com/orderingsystem/application/dto/request/SignUpApplicationRequest.java
+++ b/user/src/main/java/com/orderingsystem/application/dto/request/SignUpApplicationRequest.java
@@ -1,6 +1,6 @@
 package com.orderingsystem.application.dto.request;
 
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/user/src/main/java/com/orderingsystem/application/dto/response/UserProfileResponse.java
+++ b/user/src/main/java/com/orderingsystem/application/dto/response/UserProfileResponse.java
@@ -1,7 +1,7 @@
 package com.orderingsystem.application.dto.response;
 
 import com.orderingsystem.domain.model.UserStatus;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/user/src/main/java/com/orderingsystem/application/outbox/UserOutboxHelper.java
+++ b/user/src/main/java/com/orderingsystem/application/outbox/UserOutboxHelper.java
@@ -9,7 +9,7 @@ import com.orderingsystem.application.outbox.model.UserCreatedEventPayload;
 import com.orderingsystem.application.outbox.model.UserDeletedEventPayload;
 import com.orderingsystem.application.outbox.model.UserEventPayload;
 import com.orderingsystem.domain.exception.UserDomainException;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.model.outbox.UserOutbox;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;
 import java.time.ZonedDateTime;

--- a/user/src/main/java/com/orderingsystem/domain/model/User.java
+++ b/user/src/main/java/com/orderingsystem/domain/model/User.java
@@ -1,6 +1,7 @@
 package com.orderingsystem.domain.model;
 
 import com.orderingsystem.common.domain.AggregateRoot;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.event.UserCreatedEvent;
 import com.orderingsystem.domain.event.UserDeletedEvent;
 import jakarta.persistence.Column;

--- a/user/src/main/java/com/orderingsystem/domain/model/outbox/UserOutbox.java
+++ b/user/src/main/java/com/orderingsystem/domain/model/outbox/UserOutbox.java
@@ -1,6 +1,6 @@
 package com.orderingsystem.domain.model.outbox;
 
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/user/src/main/java/com/orderingsystem/presentation/request/SignUpRequest.java
+++ b/user/src/main/java/com/orderingsystem/presentation/request/SignUpRequest.java
@@ -1,7 +1,7 @@
 package com.orderingsystem.presentation.request;
 
 import com.orderingsystem.application.dto.request.SignUpApplicationRequest;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/user/src/main/java/com/orderingsystem/util/JwtUtil.java
+++ b/user/src/main/java/com/orderingsystem/util/JwtUtil.java
@@ -43,6 +43,7 @@ public class JwtUtil {
                 .expiration(new Date(now + accessTtl.toMillis()))
                 .claim("userId", user.getUserId().toString())
                 .claim("typ", "access")
+                .claim("role", user.getType().name())
                 .signWith(secretKey, SIG.HS256)
                 .compact();
     }

--- a/user/src/test/java/com/orderingsystem/application/AuthFacadeHelperTest.java
+++ b/user/src/test/java/com/orderingsystem/application/AuthFacadeHelperTest.java
@@ -13,7 +13,7 @@ import com.orderingsystem.application.outbox.UserOutboxHelper;
 import com.orderingsystem.common.exception.InvalidCredentialsException;
 import com.orderingsystem.domain.event.UserCreatedEvent;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/user/src/test/java/com/orderingsystem/application/AuthFacadeRotateRefreshTokenTest.java
+++ b/user/src/test/java/com/orderingsystem/application/AuthFacadeRotateRefreshTokenTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.common.exception.InvalidCredentialsException;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.RefreshTokenRepository;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;

--- a/user/src/test/java/com/orderingsystem/application/AuthFacadeSignInTest.java
+++ b/user/src/test/java/com/orderingsystem/application/AuthFacadeSignInTest.java
@@ -8,7 +8,7 @@ import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.common.exception.InvalidCredentialsException;
 import com.orderingsystem.domain.exception.UserNotFoundException;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.RefreshTokenRepository;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;

--- a/user/src/test/java/com/orderingsystem/application/AuthFacadeSignUpTest.java
+++ b/user/src/test/java/com/orderingsystem/application/AuthFacadeSignUpTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.orderingsystem.application.dto.request.SignUpApplicationRequest;
 import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.model.outbox.UserOutbox;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;

--- a/user/src/test/java/com/orderingsystem/presentation/AuthControllerRefreshTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/AuthControllerRefreshTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.RefreshTokenRepository;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;

--- a/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignInTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignInTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.RefreshTokenRepository;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;

--- a/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignUpTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignUpTest.java
@@ -11,7 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.domain.model.User;
 import com.orderingsystem.domain.model.UserStatus;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.domain.repository.outbox.UserOutboxRepository;
 import com.orderingsystem.presentation.request.SignUpRequest;

--- a/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignUpWebMvcTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/AuthControllerSignUpWebMvcTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.application.AuthFacade;
 import com.orderingsystem.application.dto.response.TokenResponse;
 import com.orderingsystem.common.util.CommonJwtUtil;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.presentation.request.SignUpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/user/src/test/java/com/orderingsystem/presentation/AuthControllerValidationTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/AuthControllerValidationTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.application.AuthFacade;
 import com.orderingsystem.common.util.CommonJwtUtil;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.presentation.request.SignInRequest;
 import com.orderingsystem.presentation.request.SignUpRequest;
 import org.junit.jupiter.api.DisplayName;

--- a/user/src/test/java/com/orderingsystem/presentation/UserControllerTest.java
+++ b/user/src/test/java/com/orderingsystem/presentation/UserControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import com.orderingsystem.domain.repository.UserRepository;
 import com.orderingsystem.presentation.request.UpdateUserRequest;
 import io.jsonwebtoken.Jwts;

--- a/user/src/test/java/com/orderingsystem/util/JwtUtilTest.java
+++ b/user/src/test/java/com/orderingsystem/util/JwtUtilTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.orderingsystem.domain.model.User;
-import com.orderingsystem.domain.model.UserType;
+import com.orderingsystem.common.domain.status.UserType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #51 

## 📝작업 내용

- 쿠폰 생성
   - 관리자만 생성 가능
   - `PERCENTAGE`, `FIXED_AMOUNT` 타입 존재
   - 쿠폰 생성 후 `TaskScheduler`에 쿠폰 배포 예약

- 쿠폰 조회
   - 쿠폰 전체 혹은 발급 받은 쿠폰 중 조회 가능

- 쿠폰 정지, 재시작, 종료 
   - 관리자만 가능
   - 정지된 쿠폰만 재시작 가능
   - 쿠폰 정지시 Redis에서 쿠폰 정보만 삭제, 발급한 유저 정보는 유지
   - 재시작시 Redis에 다시 정보 삽입
   - 쿠폰 종료시 쿠폰 정보 및 발급한 유저 정보 삭제(7일 후 삭제)

- 쿠폰 발급
   - Redis, Kafka 사용해 비동기로 구현
   - 쿠폰 중복 발급 금지 및 쿠폰 개수 제한
   - 쿠폰 발급 신청 시 Redis에 재고 차감 및 유저 등록 후 Kafka 메시지 전송
   - Kafka 메시지 받으면 DB 처리 시작

- 하루에 한 번 스케줄러를 돌려 쿠폰 `EXPIRED` 처리 및 발급된 쿠폰 `EXPIRED` 처리
   - 쿠폰 만료 및 존재 여부는 Redis로 확인하기에 하루에 한 번 처리
   - 쿠폰 조회시 현재 시간하고 비교해 발급된 쿠폰 `ISSUED`, 쿠폰 `ACTIVE` 상태라도 `EXPIRED` 상태로 내려줌