### PR TITLE
[Fix] #58 결제·쿠폰 동시 완료 시 Order 락 부재로 인한 saga 정지 버그 수정

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/order/src/main/java/com/OrderApplication.java
+++ b/order/src/main/java/com/OrderApplication.java
@@ -3,11 +3,13 @@ package com;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableRetry
 public class OrderApplication {
 
     public static void main(String[] args) {

--- a/order/src/main/java/com/orderingsystem/order/application/OrderCouponSagaCoordinator.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderCouponSagaCoordinator.java
@@ -1,0 +1,37 @@
+package com.orderingsystem.order.application;
+
+import com.orderingsystem.common.saga.SagaStep;
+import com.orderingsystem.order.application.dto.response.CouponResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCouponSagaCoordinator implements SagaStep<CouponResponse> {
+
+    private final OrderCouponService orderCouponService;
+
+    @Override
+    @Retryable(
+            retryFor = OptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    public void process(CouponResponse couponResponse) {
+        orderCouponService.process(couponResponse);
+    }
+
+    @Override
+    @Retryable(
+            retryFor = OptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    public void rollback(CouponResponse couponResponse) {
+        orderCouponService.rollback(couponResponse);
+    }
+
+}

--- a/order/src/main/java/com/orderingsystem/order/application/OrderCouponService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderCouponService.java
@@ -69,9 +69,10 @@ public class OrderCouponService implements SagaStep<CouponResponse> {
         }
 
         updateCouponOutboxMessage(couponOutboxMessage, SagaStatus.SUCCEEDED, order.getOrderStatus());
+        order.couponCompleted();
 
-        if (order.getOrderStatus().equals(OrderStatus.PAID)) {
-            log.info("주문 결제 및 쿠폰 완료. OrderId : [{}], SagaId : [{}]", orderId, sagaId);
+        if (order.isPaymentCompleted()) {
+            log.info("주문 결제 및 쿠폰 처리 완료. OrderId : [{}], SagaId : [{}]", orderId, sagaId);
 
             SagaStatus sagaStatus =
                     OrderStatusToSagaStatus.orderStatusToSagaStatus(order.getOrderStatus());

--- a/order/src/main/java/com/orderingsystem/order/application/OrderPaymentSagaCoordinator.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderPaymentSagaCoordinator.java
@@ -1,0 +1,37 @@
+package com.orderingsystem.order.application;
+
+import com.orderingsystem.common.saga.SagaStep;
+import com.orderingsystem.order.application.dto.response.PaymentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentSagaCoordinator implements SagaStep<PaymentResponse> {
+
+    private final OrderPaymentService orderPaymentService;
+
+    @Override
+    @Retryable(
+            retryFor = OptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    public void process(PaymentResponse paymentResponse) {
+        orderPaymentService.process(paymentResponse);
+    }
+
+    @Override
+    @Retryable(
+            retryFor = OptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    public void rollback(PaymentResponse paymentResponse) {
+        orderPaymentService.rollback(paymentResponse);
+    }
+
+}

--- a/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
+++ b/order/src/main/java/com/orderingsystem/order/application/OrderPaymentService.java
@@ -78,8 +78,8 @@ public class OrderPaymentService implements SagaStep<PaymentResponse> {
                 OrderStatusToSagaStatus.orderStatusToSagaStatus(orderPaidEvent.getOrder().getOrderStatus());
 
         if (hasCoupon) {
-            if (couponOutboxHelper.isCouponProcessed(paymentResponse.getSagaId())) {
-                log.info("주문 결제 및 쿠폰 완료. OrderId : [{}], SagaId : [{}]",
+            if (order.isCouponCompleted()) {
+                log.info("주문 결제 및 쿠폰 처리 완료. OrderId : [{}], SagaId : [{}]",
                         paymentResponse.getOrderId(), paymentResponse.getSagaId());
                 sendToRestaurant(paymentResponse.getSagaId(), orderPaidEvent, sagaStatus, paymentOutboxMessage);
             } else {

--- a/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -71,6 +72,9 @@ public class Order extends AggregateRoot {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "json")
     private List<Long> couponIds;
+
+    @Version
+    private Long version;
 
     @Override
     public boolean equals(Object o) {

--- a/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
+++ b/order/src/main/java/com/orderingsystem/order/domain/model/Order.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -75,6 +76,9 @@ public class Order extends AggregateRoot {
 
     @Version
     private Long version;
+
+    private Instant paymentCompletedAt;
+    private Instant couponCompletedAt;
 
     @Override
     public boolean equals(Object o) {
@@ -155,6 +159,7 @@ public class Order extends AggregateRoot {
             throw new OrderDomainException("결제를 진행할 수 없는 주문 상태입니다.");
         }
         orderStatus = OrderStatus.PAID;
+        this.paymentCompletedAt = Instant.now();
 
         return new OrderPaidEvent(this, ZonedDateTime.now());
     }
@@ -238,6 +243,18 @@ public class Order extends AggregateRoot {
 
     public boolean hasCoupon() {
         return !(this.couponIds == null || this.couponIds.isEmpty());
+    }
+
+    public boolean isPaymentCompleted() {
+        return paymentCompletedAt != null;
+    }
+
+    public boolean isCouponCompleted() {
+        return couponCompletedAt != null;
+    }
+
+    public void couponCompleted() {
+        couponCompletedAt = Instant.now();
     }
 
 }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/CouponResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/CouponResponseKafkaListener.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.DebeziumOp;
 import com.orderingsystem.kafka.KafkaConsumer;
-import com.orderingsystem.order.application.OrderCouponService;
+import com.orderingsystem.order.application.OrderCouponSagaCoordinator;
 import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.infra.kafka.message.CouponResponseDebeziumMessage;
 import com.orderingsystem.order.infra.kafka.message.CouponResponseMessage;
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class CouponResponseKafkaListener implements KafkaConsumer<String> {
 
     private final ObjectMapper objectMapper;
-    private final OrderCouponService orderCouponService;
+    private final OrderCouponSagaCoordinator orderCouponSagaCoordinator;
 
     @Override
     @KafkaListener(id = "${kafka-consumer-config.coupon-response-consumer-group-id}",
@@ -57,13 +57,13 @@ public class CouponResponseKafkaListener implements KafkaConsumer<String> {
                     if ((responseMessage.getFailureMessages() == null || responseMessage.getFailureMessages().isEmpty())
                             && responseMessage.getUpdatedCount() > 0) {
                         log.info("쿠폰 사용 성공. Order Id : [{}]", responseMessage.getOrderId());
-                        orderCouponService.process(responseMessage.toCouponResponse(
+                        orderCouponSagaCoordinator.process(responseMessage.toCouponResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     } else {
                         log.info("쿠폰 사용 실패. Order Id : {}, failureMessage: [{}], updatedCount : {}",
                                 responseMessage.getOrderId(), responseMessage.getFailureMessages(),
                                 responseMessage.getUpdatedCount());
-                        orderCouponService.rollback(responseMessage.toCouponResponse(
+                        orderCouponSagaCoordinator.rollback(responseMessage.toCouponResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     }
                 }

--- a/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
+++ b/order/src/main/java/com/orderingsystem/order/infra/kafka/listener/PaymentResponseKafkaListener.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orderingsystem.common.domain.status.DebeziumOp;
 import com.orderingsystem.common.domain.status.PaymentStatus;
 import com.orderingsystem.kafka.KafkaConsumer;
-import com.orderingsystem.order.application.OrderPaymentService;
+import com.orderingsystem.order.application.OrderPaymentSagaCoordinator;
 import com.orderingsystem.order.application.OrderRestaurantApprovalService;
 import com.orderingsystem.order.application.exception.OrderApplicationException;
 import com.orderingsystem.order.infra.kafka.message.PaymentResponseDebeziumMessage;
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 public class PaymentResponseKafkaListener implements KafkaConsumer<String> {
 
     private final ObjectMapper objectMapper;
-    private final OrderPaymentService orderPaymentService;
+    private final OrderPaymentSagaCoordinator orderPaymentSagaCoordinator;
     private final OrderRestaurantApprovalService orderRestaurantApprovalService;
 
     @Override
@@ -59,15 +59,15 @@ public class PaymentResponseKafkaListener implements KafkaConsumer<String> {
 
                     if (PaymentStatus.COMPLETED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                         log.info("결제 완료. order Id : {}", paymentResponseMessage.getOrderId());
-                        orderPaymentService.process(paymentResponseMessage.toPaymentResponse(
+                        orderPaymentSagaCoordinator.process(paymentResponseMessage.toPaymentResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     } else if (PaymentStatus.CANCELLED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                         log.info("결제 취소. order Id : {}", paymentResponseMessage.getOrderId());
-                        orderPaymentService.rollback(paymentResponseMessage.toPaymentResponse(
+                        orderPaymentSagaCoordinator.rollback(paymentResponseMessage.toPaymentResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     } else if (PaymentStatus.FAILED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                         log.info("결제 실패. order Id : {}", paymentResponseMessage.getOrderId());
-                        orderPaymentService.rollback(paymentResponseMessage.toPaymentResponse(
+                        orderPaymentSagaCoordinator.rollback(paymentResponseMessage.toPaymentResponse(
                                 UUID.fromString(debeziumMessage.getAfter().getId())));
                     } else if (PaymentStatus.REFUNDED.name().equals(paymentResponseMessage.getPaymentStatus())) {
                         orderRestaurantApprovalService.reject(paymentResponseMessage.toPaymentResponse(

--- a/order/src/test/java/com/orderingsystem/order/application/OrderCouponSagaCoordinatorRetryTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderCouponSagaCoordinatorRetryTest.java
@@ -1,0 +1,113 @@
+package com.orderingsystem.order.application;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.order.application.dto.response.CouponResponse;
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(OrderCouponSagaCoordinatorRetryTest.RetryTestConfig.class)
+class OrderCouponSagaCoordinatorRetryTest {
+
+    @Configuration
+    @EnableRetry(proxyTargetClass = true)
+    static class RetryTestConfig {
+
+        @Bean
+        OrderCouponService orderCouponService() {
+            return mock(OrderCouponService.class);
+        }
+
+        @Bean
+        OrderCouponSagaCoordinator orderCouponSagaCoordinator(OrderCouponService orderCouponService) {
+            return new OrderCouponSagaCoordinator(orderCouponService);
+        }
+    }
+
+    @Resource
+    private OrderCouponService orderCouponService;
+
+    @Resource
+    private OrderCouponSagaCoordinator orderCouponSagaCoordinator;
+
+    private CouponResponse couponResponse;
+
+    @BeforeEach
+    void setUp() {
+        couponResponse = CouponResponse.builder().build();
+        org.mockito.Mockito.reset(orderCouponService);
+    }
+
+    @Test
+    @DisplayName("낙관적 락 충돌이 2번 발생하고 3번째에 성공하면, process()는 예외 없이 총 3번 호출된다")
+    void shouldSucceedAndCallThreeTimes_whenOptimisticLockingFailureOccursTwiceAndSucceedsOnThird() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doNothing()
+                .when(orderCouponService).process(any());
+
+        //when, then
+        assertThatCode(() -> orderCouponSagaCoordinator.process(couponResponse))
+                .doesNotThrowAnyException();
+
+        verify(orderCouponService, times(3)).process(any());
+    }
+
+    @Test
+    @DisplayName("maxAttempts(3)를 초과해 계속 충돌하면 결국 예외가 호출부로 전파된다")
+    void shouldPropagateException_whenRetriesExceedMaxAttempts() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .when(orderCouponService).process(any());
+
+        //when, then
+        assertThatThrownBy(() -> orderCouponSagaCoordinator.process(couponResponse))
+                .isInstanceOf(OptimisticLockingFailureException.class);
+
+        verify(orderCouponService, times(3)).process(any());
+    }
+
+    @Test
+    @DisplayName("첫 시도에 바로 성공하면 재시도 없이 1번만 호출된다")
+    void shouldCallOnlyOnce_whenSucceedsOnFirstAttempt() {
+        //given
+        doNothing().when(orderCouponService).process(any());
+
+        //when
+        orderCouponSagaCoordinator.process(couponResponse);
+
+        //then
+        verify(orderCouponService, times(1)).process(any());
+    }
+
+    @Test
+    @DisplayName("rollback()도 동일하게 재시도가 적용된다")
+    void shouldRetry_whenOptimisticLockingFailureOccursOnRollback() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doNothing()
+                .when(orderCouponService).rollback(any());
+
+        //when, then
+        assertThatCode(() -> orderCouponSagaCoordinator.rollback(couponResponse))
+                .doesNotThrowAnyException();
+
+        verify(orderCouponService, times(2)).rollback(any());
+    }
+
+}

--- a/order/src/test/java/com/orderingsystem/order/application/OrderCouponServiceTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderCouponServiceTest.java
@@ -69,7 +69,8 @@ class OrderCouponServiceTest {
         given(couponOutboxHelper.getCouponOutboxBySagaIdAndSagaStatus(sagaId, SagaStatus.STARTED))
                 .willReturn(Optional.of(couponOutbox));
 
-        Order order = createOrder(orderId, OrderStatus.PAID);
+        Order order = createOrder(orderId, OrderStatus.PENDING);
+        order.pay();
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         given(processedMessageRepository.insertIgnore(any(), any(), any())).willReturn(1);

--- a/order/src/test/java/com/orderingsystem/order/application/OrderOptimisticLockingTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderOptimisticLockingTest.java
@@ -1,0 +1,84 @@
+package com.orderingsystem.order.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.orderingsystem.common.domain.Money;
+import com.orderingsystem.order.domain.model.Order;
+import com.orderingsystem.order.domain.repository.OrderRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class OrderOptimisticLockingTest {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    @Test
+    @DisplayName("동시에 두 트랜잭션이 같은 버전의 Order를 수정하고 커밋하려 하면 두 번째 커밋은 예외가 발생한다")
+    void shouldThrowOptimisticLockingFailure_whenConcurrentUpdateOnSameVersion() {
+        //given
+        Order saved = orderRepository.saveAndFlush(newPendingOrder());
+        entityManager.clear();
+
+        Order paymentThreadView = orderRepository.findById(saved.getId()).orElseThrow();
+        entityManager.clear();
+
+        Order couponThreadView = orderRepository.findById(saved.getId()).orElseThrow();
+
+        //when
+        couponThreadView.couponCompleted();
+        orderRepository.saveAndFlush(couponThreadView);
+        entityManager.clear();
+
+        //then
+        paymentThreadView.pay();
+        assertThatThrownBy(() -> orderRepository.saveAndFlush(paymentThreadView))
+                .isInstanceOf(OptimisticLockingFailureException.class);
+    }
+
+    @Test
+    @DisplayName("충돌 후 다시 조회해서 재시도하면 최신 상태(상대방이 커밋한 값)를 반영해 정상 저장된다")
+    void shouldSucceedAndReflectLatestState_whenRetriedWithFreshReadAfterConflict() {
+        //given
+        Order saved = orderRepository.saveAndFlush(newPendingOrder());
+        entityManager.clear();
+
+        Order couponThreadView = orderRepository.findById(saved.getId()).orElseThrow();
+        couponThreadView.couponCompleted();
+        orderRepository.saveAndFlush(couponThreadView);
+        entityManager.clear();
+
+        //when
+        Order refetched = orderRepository.findById(saved.getId()).orElseThrow();
+        refetched.pay();
+        orderRepository.saveAndFlush(refetched);
+
+        //then
+        entityManager.clear();
+        Order result = orderRepository.findById(saved.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(result.isPaymentCompleted()).isTrue();
+        org.assertj.core.api.Assertions.assertThat(result.isCouponCompleted()).isTrue();
+    }
+
+    private Order newPendingOrder() {
+        Order order = Order.builder()
+                .price(new Money(BigDecimal.valueOf(10_000)))
+                .items(List.of())
+                .couponIds(List.of(1L))
+                .build();
+        order.initializeOrder();
+        return order;
+    }
+
+}

--- a/order/src/test/java/com/orderingsystem/order/application/OrderPaymentSagaCoordinatorRetryTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderPaymentSagaCoordinatorRetryTest.java
@@ -1,0 +1,114 @@
+package com.orderingsystem.order.application;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.orderingsystem.order.application.dto.response.PaymentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import jakarta.annotation.Resource;
+
+@SpringJUnitConfig(OrderPaymentSagaCoordinatorRetryTest.RetryTestConfig.class)
+class OrderPaymentSagaCoordinatorRetryTest {
+
+    @Configuration
+    @EnableRetry(proxyTargetClass = true)
+    static class RetryTestConfig {
+
+        @Bean
+        OrderPaymentService orderPaymentService() {
+            return mock(OrderPaymentService.class);
+        }
+
+        @Bean
+        OrderPaymentSagaCoordinator orderPaymentSagaCoordinator(OrderPaymentService orderPaymentService) {
+            return new OrderPaymentSagaCoordinator(orderPaymentService);
+        }
+    }
+
+    @Resource
+    private OrderPaymentService orderPaymentService;
+
+    @Resource
+    private OrderPaymentSagaCoordinator orderPaymentSagaCoordinator;
+
+    private PaymentResponse paymentResponse;
+
+    @BeforeEach
+    void setUp() {
+        paymentResponse = PaymentResponse.builder().build();
+        org.mockito.Mockito.reset(orderPaymentService);
+    }
+
+    @Test
+    @DisplayName("낙관적 락 충돌이 2번 발생하고 3번째에 성공하면, process()는 예외 없이 총 3번 호출된다")
+    void shouldSucceedAndCallThreeTimes_whenOptimisticLockingFailureOccursTwiceAndSucceedsOnThird() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doNothing()
+                .when(orderPaymentService).process(any());
+
+        //when, then
+        assertThatCode(() -> orderPaymentSagaCoordinator.process(paymentResponse))
+                .doesNotThrowAnyException();
+
+        verify(orderPaymentService, times(3)).process(any());
+    }
+
+    @Test
+    @DisplayName("maxAttempts(3)를 초과해 계속 충돌하면 결국 예외가 호출부로 전파된다")
+    void shouldPropagateException_whenRetriesExceedMaxAttempts() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .when(orderPaymentService).process(any());
+
+        //when, then
+        assertThatThrownBy(() -> orderPaymentSagaCoordinator.process(paymentResponse))
+                .isInstanceOf(OptimisticLockingFailureException.class);
+
+        verify(orderPaymentService, times(3)).process(any());
+    }
+
+    @Test
+    @DisplayName("첫 시도에 바로 성공하면 재시도 없이 1번만 호출된다")
+    void shouldCallOnlyOnce_whenSucceedsOnFirstAttempt() {
+        //given
+        doNothing().when(orderPaymentService).process(any());
+
+        //when
+        orderPaymentSagaCoordinator.process(paymentResponse);
+
+        //then
+        verify(orderPaymentService, times(1)).process(any());
+    }
+
+    @Test
+    @DisplayName("rollback()도 동일하게 재시도가 적용된다")
+    void shouldRetry_whenOptimisticLockingFailureOccursOnRollback() {
+        //given
+        doThrow(new OptimisticLockingFailureException("version conflict"))
+                .doNothing()
+                .when(orderPaymentService).rollback(any());
+
+        //when, then
+        assertThatCode(() -> orderPaymentSagaCoordinator.rollback(paymentResponse))
+                .doesNotThrowAnyException();
+
+        verify(orderPaymentService, times(2)).rollback(any());
+    }
+
+}

--- a/order/src/test/java/com/orderingsystem/order/application/OrderPaymentServiceProcessTest.java
+++ b/order/src/test/java/com/orderingsystem/order/application/OrderPaymentServiceProcessTest.java
@@ -127,8 +127,9 @@ class OrderPaymentServiceProcessTest {
     @Test
     void process_proceed_when_coupon_processed() {
         //given
-        saveOrder(OrderStatus.PENDING, List.of(1L));
+        Order order = saveOrder(OrderStatus.PENDING, List.of(1L));
         saveCouponOutbox(SagaStatus.SUCCEEDED);
+        order.couponCompleted();
 
         PaymentResponse paymentResponse = getPaymentResponse(sagaId, orderId);
 
@@ -136,8 +137,8 @@ class OrderPaymentServiceProcessTest {
         orderPaymentService.process(paymentResponse);
 
         //then
-        Optional<Order> order = orderRepository.findById(orderId);
-        assertThat(order.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
+        Optional<Order> afterOrder = orderRepository.findById(orderId);
+        assertThat(afterOrder.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
 
         assertThat(restaurantAcceptOutboxRepository.count()).isEqualTo(1);
     }
@@ -286,8 +287,8 @@ class OrderPaymentServiceProcessTest {
                 .build();
     }
 
-    private void saveOrder(OrderStatus orderStatus, List<Long> couponIds) {
-        orderRepository.save(Order.builder()
+    private Order saveOrder(OrderStatus orderStatus, List<Long> couponIds) {
+        return orderRepository.save(Order.builder()
                 .id(orderId)
                 .customerId(customerId)
                 .restaurantId(restaurantId)

--- a/order/src/test/java/com/orderingsystem/order/presentation/OrderControllerCancelOrderTest.java
+++ b/order/src/test/java/com/orderingsystem/order/presentation/OrderControllerCancelOrderTest.java
@@ -109,7 +109,7 @@ class OrderControllerCancelOrderTest {
 
         //when
         mockMvc.perform(
-                        post("/api/order/" + order.getTrackingId() + "/cancel")
+                        post("/api/orders/" + order.getTrackingId() + "/cancel")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isNoContent());
@@ -157,7 +157,7 @@ class OrderControllerCancelOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order/" + order.getTrackingId() + "/cancel")
+                        post("/api/orders/" + order.getTrackingId() + "/cancel")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isBadRequest())
@@ -203,7 +203,7 @@ class OrderControllerCancelOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order/" + order.getTrackingId() + "/cancel")
+                        post("/api/orders/" + order.getTrackingId() + "/cancel")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isNotFound())
@@ -223,7 +223,7 @@ class OrderControllerCancelOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order/" + UUID.randomUUID() + "/cancel")
+                        post("/api/orders/" + UUID.randomUUID() + "/cancel")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isNotFound())
@@ -257,7 +257,7 @@ class OrderControllerCancelOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order/" + order.getTrackingId() + "/cancel")
+                        post("/api/orders/" + order.getTrackingId() + "/cancel")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isForbidden())

--- a/order/src/test/java/com/orderingsystem/order/presentation/OrderControllerCreateOrderTest.java
+++ b/order/src/test/java/com/orderingsystem/order/presentation/OrderControllerCreateOrderTest.java
@@ -113,7 +113,7 @@ class OrderControllerCreateOrderTest {
 
         //when
         MvcResult mvcResult = mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -148,7 +148,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -175,7 +175,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -206,7 +206,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -235,7 +235,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -258,7 +258,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -282,7 +282,7 @@ class OrderControllerCreateOrderTest {
 
         //when, then
         mockMvc.perform(
-                        post("/api/order")
+                        post("/api/orders")
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .content(objectMapper.writeValueAsString(createOrderRequest))
                                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 연관된 이슈

> #58 

## 작업 내용

## 문제
쿠폰이 포함된 주문은 결제 완료와 쿠폰 완료가 서로 다른 Kafka consumer 스레드에서 비동기로 처리되고, 둘 다 끝나야 레스토랑 접수 요청이 발행된다.
Order 엔티티에 락이 없어 두 이벤트가 거의 동시에 도착하면, 양쪽 트랜잭션이 다음 단계를 트리거하지 않아 주문이 멈추는 레이스 컨디션이 있었음.

## 변경 사항
- Order에 `@Version` 추가해 낙관적 락 적용
- paymentCompletedAt / couponCompletedAt 필드 추가, 두 서비스가 동일한 방식으로 상대방 완료 여부를 확인하도록 통일 (기존엔 한쪽은 outbox 테이블 직접 조회, 한쪽은 order 상태 필드 조회로 비대칭)
- `OrderPaymentSagaCoordinator` 추가: OrderPaymentService를 감싸서 OptimisticLockingFailureException 발생 시 자동 재시도 (@Retryable,최대 3회, backoff 100ms~)
- `OrderCouponSagaCoordinator` 추가: OrderCouponService를 감싸서 동일한 방식으로 자동 재시도 적용
- PaymentResponseKafkaListener가 OrderPaymentService 대신 OrderPaymentSagaCoordinator를 호출하도록 변경
- CouponResponseKafkaListener가 OrderCouponService 대신 OrderCouponSagaCoordinator를 호출하도록 변경
- OrderApplication에 @EnableRetry 추가

## 테스트
- OrderOptimisticLockingTest: 동시 커밋 시 버전 충돌 발생 및 재조회 후 재시도시 정상 반영되는지 검증
- OrderPaymentSagaCoordinatorRetryTest: 결제 쪽 @Retryable이 실제로 재시도되는지, maxAttempts 초과 시 예외가 전파되는지 검증
- OrderCouponSagaCoordinatorRetryTest: 쿠폰 쪽도 동일하게 재시도/예외 전파 검증
