### PR TITLE
[Fix] #60 AuthorizationFilter의 문자열 contains() 기반 경로 매칭을 정확한 패턴 매칭으로 교체

### DIFF
--- a/api-gateway/src/main/java/com/orderingsystem/apigateway/filter/AuthorizationFilter.java
+++ b/api-gateway/src/main/java/com/orderingsystem/apigateway/filter/AuthorizationFilter.java
@@ -12,6 +12,7 @@ import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -19,6 +20,9 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Component
 public class AuthorizationFilter implements GlobalFilter, Ordered {
+
+    private static final String ADMIN_PATH_PATTERN = "/api/*/admin/**";
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
     private final CommonJwtUtil commonJwtUtil;
 
@@ -33,15 +37,14 @@ public class AuthorizationFilter implements GlobalFilter, Ordered {
         ServerHttpRequest request = exchange.getRequest();
         String path = request.getURI().getPath();
 
-        if (path.contains(signInPath) || path.contains(signUpPath)){
+        if (isPermitAllPath(path)) {
             log.info("로그인/회원가입 요청  Path : [{}]", path);
             return chain.filter(exchange);
         }
 
         String authHeader = request.getHeaders().getFirst("Authorization");
 
-
-        if (authHeader == null || !authHeader.startsWith("Bearer")){
+        if (authHeader == null || !authHeader.startsWith("Bearer")) {
             log.info("인증 토큰이 없습니다. Path : [{}]", path);
             exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
             return exchange.getResponse().setComplete();
@@ -50,16 +53,22 @@ public class AuthorizationFilter implements GlobalFilter, Ordered {
         UserType role = commonJwtUtil.getUserRoleFromToken(authHeader);
         UUID userId = commonJwtUtil.getUserIdFromToken(authHeader);
 
-        if (path.contains("/admin/")){
-            if (!UserType.ADMIN.equals(role)){
-                log.info("관리자가 아닌 유저가 관리자 경로 접근 시도. User ID : [{}], Path : [{}]", userId, path);
-                exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
-                return exchange.getResponse().setComplete();
-            }
+        if (isAdminPath(path) && !UserType.ADMIN.equals(role)) {
+            log.info("관리자가 아닌 유저가 관리자 경로 접근 시도. User ID : [{}], Path : [{}]", userId, path);
+            exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+            return exchange.getResponse().setComplete();
         }
 
         log.info("요청이 gateway를 통과했습니다. User Id : [{}], Path : [{}]", userId, path);
         return chain.filter(exchange);
+    }
+
+    private boolean isPermitAllPath(String path) {
+        return PATH_MATCHER.match(signInPath, path) || PATH_MATCHER.match(signUpPath, path);
+    }
+
+    private boolean isAdminPath(String path) {
+        return PATH_MATCHER.match(ADMIN_PATH_PATTERN, path);
     }
 
     @Override

--- a/api-gateway/src/test/java/com/orderingsystem/apigateway/filter/AuthorizationFilterTest.java
+++ b/api-gateway/src/test/java/com/orderingsystem/apigateway/filter/AuthorizationFilterTest.java
@@ -1,0 +1,210 @@
+package com.orderingsystem.apigateway.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.orderingsystem.common.domain.status.UserType;
+import com.orderingsystem.common.util.CommonJwtUtil;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizationFilterTest {
+
+    private static final String SIGN_IN_PATH = "/api/users/auth/sign-in";
+    private static final String SIGN_UP_PATH = "/api/users/auth/sign-up";
+
+    @Mock
+    private CommonJwtUtil commonJwtUtil;
+
+    @Mock
+    private GatewayFilterChain chain;
+
+    private AuthorizationFilter authorizationFilter;
+
+    @BeforeEach
+    void setUp() {
+        authorizationFilter = new AuthorizationFilter(commonJwtUtil);
+        ReflectionTestUtils.setField(authorizationFilter, "signInPath", SIGN_IN_PATH);
+        ReflectionTestUtils.setField(authorizationFilter, "signUpPath", SIGN_UP_PATH);
+    }
+
+    private ServerWebExchange exchangeFor(String path, String authHeader) {
+        MockServerHttpRequest.BaseBuilder<?> builder = MockServerHttpRequest.get(path);
+        if (authHeader != null) {
+            builder = builder.header("Authorization", authHeader);
+        }
+        return MockServerWebExchange.from(builder.build());
+    }
+
+    @Nested
+    @DisplayName("permit-all 경로 (로그인/회원가입)")
+    class PermitAll {
+
+        @Test
+        @DisplayName("정확히 sign-in 경로면 인증 없이 통과한다")
+        void shouldPassWithoutAuth_whenPathIsExactSignInPath() {
+            //given
+            ServerWebExchange exchange = exchangeFor(SIGN_IN_PATH, null);
+            when(chain.filter(exchange)).thenReturn(Mono.empty());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            verify(chain, times(1)).filter(exchange);
+            verify(commonJwtUtil, never()).getUserRoleFromToken(any());
+        }
+
+        @Test
+        @DisplayName("정확히 sign-up 경로면 인증 없이 통과한다")
+        void shouldPassWithoutAuth_whenPathIsExactSignUpPath() {
+            //given
+            ServerWebExchange exchange = exchangeFor(SIGN_UP_PATH, null);
+            when(chain.filter(exchange)).thenReturn(Mono.empty());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            verify(chain, times(1)).filter(exchange);
+        }
+
+        @Test
+        @DisplayName("[보안 회귀 테스트] sign-in과 같은 세그먼트를 포함하지만 실제로는 다른 엔드포인트면 permit-all로 처리되지 않고 인증을 요구해야 한다 (기존 contains() 버그 재현 케이스)")
+        void shouldRequireAuth_whenPathContainsSignInAsSubstringButIsNotPermitAllPath() {
+            //given
+            ServerWebExchange exchange = exchangeFor("/api/products/auth/sign-in-recommendations", null);
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            verify(chain, never()).filter(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 헤더 검증")
+    class AuthHeader {
+
+        @Test
+        @DisplayName("Authorization 헤더가 없으면 401을 반환한다")
+        void shouldReturn401_whenAuthHeaderIsMissing() {
+            //given
+            ServerWebExchange exchange = exchangeFor("/api/orders", null);
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            verify(chain, never()).filter(any());
+        }
+
+        @Test
+        @DisplayName("Bearer로 시작하지 않는 토큰이면 401을 반환한다")
+        void shouldReturn401_whenTokenDoesNotStartWithBearer() {
+            //given
+            ServerWebExchange exchange = exchangeFor("/api/orders", "Basic abcdef");
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    @Nested
+    @DisplayName("admin 경로 권한 체크")
+    class AdminPath {
+
+        @Test
+        @DisplayName("admin 경로에 ADMIN 권한이면 통과한다")
+        void shouldPass_whenUserHasAdminRoleOnAdminPath() {
+            //given
+            String authHeader = "Bearer valid-admin-token";
+            ServerWebExchange exchange = exchangeFor("/api/restaurants/admin/menu", authHeader);
+            when(chain.filter(exchange)).thenReturn(Mono.empty());
+            when(commonJwtUtil.getUserRoleFromToken(authHeader)).thenReturn(UserType.ADMIN);
+            when(commonJwtUtil.getUserIdFromToken(authHeader)).thenReturn(UUID.randomUUID());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            verify(chain, times(1)).filter(exchange);
+        }
+
+        @Test
+        @DisplayName("admin 경로에 ADMIN이 아닌 권한이면 403을 반환한다")
+        void shouldReturn403_whenUserIsNotAdminOnAdminPath() {
+            //given
+            String authHeader = "Bearer valid-customer-token";
+            ServerWebExchange exchange = exchangeFor("/api/restaurants/admin/menu", authHeader);
+            when(commonJwtUtil.getUserRoleFromToken(authHeader)).thenReturn(UserType.CUSTOMER);
+            when(commonJwtUtil.getUserIdFromToken(authHeader)).thenReturn(UUID.randomUUID());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            verify(chain, never()).filter(any());
+        }
+
+        @Test
+        @DisplayName("[보안 회귀 테스트] '/admin/'을 부분 문자열로만 포함하고 실제 admin 세그먼트가 아니면 관리자 권한을 요구하지 않아야 한다 (기존 contains(\"/admin/\") 오탐 케이스)")
+        void shouldPassWithoutAdminRole_whenPathContainsAdminAsSubstringButIsNotAdminSegment() {
+            //given
+            String authHeader = "Bearer valid-customer-token";
+            ServerWebExchange exchange = exchangeFor("/api/products/admin-events/list", authHeader);
+            when(chain.filter(exchange)).thenReturn(Mono.empty());
+            when(commonJwtUtil.getUserRoleFromToken(authHeader)).thenReturn(UserType.CUSTOMER);
+            when(commonJwtUtil.getUserIdFromToken(authHeader)).thenReturn(UUID.randomUUID());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            verify(chain, times(1)).filter(exchange);
+        }
+
+        @Test
+        @DisplayName("일반 사용자 경로는 ADMIN 여부와 무관하게 통과한다")
+        void shouldPass_whenAccessingGeneralPathRegardlessOfRole() {
+            //given
+            String authHeader = "Bearer valid-customer-token";
+            ServerWebExchange exchange = exchangeFor("/api/orders/123", authHeader);
+            when(chain.filter(exchange)).thenReturn(Mono.empty());
+            when(commonJwtUtil.getUserRoleFromToken(authHeader)).thenReturn(UserType.CUSTOMER);
+            when(commonJwtUtil.getUserIdFromToken(authHeader)).thenReturn(UUID.randomUUID());
+
+            //when
+            authorizationFilter.filter(exchange, chain).block();
+
+            //then
+            verify(chain, times(1)).filter(exchange);
+        }
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60 

## 📝작업 내용

## 문제
AuthorizationFilter가 로그인/회원가입 permit-all 경로 판단과 admin 경로 권한 체크를 String.contains()로 하고 있었음. 부분 문자열만 일치해도 true가 되기 때문에, sign-in을 부분 문자열로 포함하는 무관한 경로가 인증을 우회할 수 있고, 반대로 "/admin/"을 포함하는 의도치 않은 경로가 관리자 권한을 요구받을 수도 있는 보안 취약점 존재

## 변경 사항
- contains() 기반 경로 판단을 AntPathMatcher.match()로 교체 (isPermitAllPath, isAdminPath로 분리)
- path.sign-in / path.sign-up yml 값을 실제 게이트웨이 진입 전체 경로로 수정
  → match()는 완전 일치 기반이라 기존처럼 일부 경로만 넣으면 매칭이 안 됨
- admin 경로 판단용 ADMIN_PATH_PATTERN("/api/*/admin/**") 추가 (실제 admin 라우팅 prefix에 맞춰 조정 필요)

## 참고
- ADMIN_PATH_PATTERN 실제 서비스별 admin 라우팅 규칙에 맞게 재조정 필요
- 향후 API 버저닝(v1, v2 등) 도입 시 패턴에 /v*/ 세그먼트 추가하거나, permit-all 경로를 리스트로 외부화하는 방식 고려
